### PR TITLE
Add some parameters for the NVIDIA driver module

### DIFF
--- a/etc/modprobe.d/nvidia.conf
+++ b/etc/modprobe.d/nvidia.conf
@@ -1,0 +1,1 @@
+options nvidia NVreg_EnablePCIeGen3=1 NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0


### PR DESCRIPTION
Adding a some of important parameters for driver modules.

I'll make a few remarks:

`NVreg_UsePageAttributeTable=1` (Default 0) -  Improves CPU performance on laptops (See https://bbs.archlinux.org/viewtopic.php?id=242007).
`NVreg_EnablePCIeGen3=1` (Default 0) - Enables full PCIe 3.0 support for graphics cards. The following is written in nv-reg.h about this parameter:

>  Due to interoperability problems seen with Kepler PCIe Gen3 capable GPUs
>  when configured on SandyBridge E desktop platforms, NVIDIA feels that
>  delivering a reliable, high-quality experience is not currently possible in
>  PCIe Gen3 mode on all PCIe Gen3 platforms. Therefore, Quadro, Tesla and
>  NVS Kepler products operate in PCIe Gen2 mode by default. You may use this
>  option to enable PCIe Gen3 support.

However, in home configurations for which CachyOS is intended, most people probably do not use either Tesla or Quadro. Support for Kepler, which as indicated had problems with PCIe 3.0, is also discontinued with the 510 driver version.

`NVreg_InitializeSystemMemoryAllocations=0` (Default 1) - Disables
clearing system memory allocation before using it for the GPU. Has potential security risks, but it also potentially increases performance.

A full description can be found in my nvidia-tweaks package:
https://aur.archlinux.org/cgit/aur.git/tree/nvidia.conf?h=nvidia-tweaks

Also my deprecated patch:
https://aur.archlinux.org/cgit/aur.git/tree/0004-NVreg-Improvements.patch?h=nvidia-dkms-performance

As I said these changes may partly break some things (although I personally have not had any problems with these parameters on my 1050 Ti), but I suggest at least adding `NVreg_UsePageAttributeTable=1` by default and other parameters at your discretion.

@ptr1337 