### PR TITLE
Update 99-cachyos-settings.conf

### DIFF
--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -32,6 +32,11 @@ vm.dirty_background_ratio = 5
 # tunable expresses the interval between those wakeups, in 100'ths of a second (Default is 500).
 vm.dirty_writeback_centisecs = 1500
 
+# This file contains the maximum number of memory map areas a process may have. Memory map areas are used as a side-effect of calling malloc, directly by mmap, mprotect, and madvise, and also when loading shared libraries.
+# While most applications need less than a thousand maps, certain programs, particularly malloc debuggers, may consume lots of them, e.g., up to one or two maps per allocation.
+# The default value is 65536
+vm.max_map_count = 16777216
+
 # This action will speed up your boot and shutdown, because one less module is loaded. Additionally disabling watchdog timers increases performance and lowers power consumption
 # Disable NMI watchdog
 kernel.nmi_watchdog = 0


### PR DESCRIPTION
Related to changes in the nobara linux for: https://nobaraproject.org/ 
It could also help with Star Citizen or other games extensive for memory.

I tested, and Warframe has more stable frametimes.