### PR TITLE
Enable NVIDIA DRM KMS by default

### DIFF
--- a/etc/modprobe.d/nvidia.conf
+++ b/etc/modprobe.d/nvidia.conf
@@ -1,1 +1,2 @@
 options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0
+options nvidia_drm modeset=1


### PR DESCRIPTION
We need this to enable NVIDIA PRIME Sync on laptops (a guaranteed way to fix tearing). It also requires a special hook to update initramfs every time the driver is updated, so it's Draft for now. 