### PR TITLE
udev: Add ZRAM recompression by default

### DIFF
--- a/etc/udev/rules.d/30-zram.rules
+++ b/etc/udev/rules.d/30-zram.rules
@@ -1,0 +1,2 @@
+ACTION=="add", KERNEL=="zram[0-9]*", ATTR{recomp_algorithm}=="", ATTR{recomp_algorithm}="algo=lz4 priority=1"
+IMPORT{program}="/sbin/sh -c \"echo \"type=idle\" > /sys/block/zram*/recompress\""


### PR DESCRIPTION
Since we already have `CONFIG_ZRAM_MULTI_COMP` enabled in our kernel, I thought that we could provide by default recompressions to ZRAM.  Double compression will save more memory for those pages that cannot be compressed with Zstd (since we use it by default), in this PR I decided to set double compression only for idle pages, since huge pages were reverted with the commit https://github.com/CachyOS/CachyOS-Settings/commit/48f40a564135a80ff23463d66e129856bbdcfe38. The re-compression algorithm can be changed in the future, for now I stopped at LZ4.

This was done as a udev rule as a temporary solution, since it is better to have this feature directly in the zram-generator, but until it is absent we will limit ourselves to this rule.

It also works only for kernel versions 6.2 and higher, for versions of the kernel below this should not create due to the checks (I tested at linux-zen 6.1, no errors).

Note: I know that recompression may cause additional CPU overhead, but I don't think it will be too critical. Additionally, we can limit this via the `threshold` parameter. Anyway, it's interesting to hear your opinion @sirlucjan @ptr1337 