### PR TITLE
nvidia: Enable dynamic power management by default

### DIFF
--- a/etc/modprobe.d/nvidia.conf
+++ b/etc/modprobe.d/nvidia.conf
@@ -1,2 +1,2 @@
-options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0
+options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02
 options nvidia_drm modeset=1


### PR DESCRIPTION
It helps laptop configurations and almost does not interfere with systems that do not support it (this will simply cause the following display of status in `/proc/driver/nvidia/gpus/0000:01:00.0/power` - `Runtime D3 status: Not supported`).

This is also already included in the Negativo17 driver for Fedora:
https://github.com/negativo17/nvidia-kmod-common/blob/master/nvidia.conf