### PR TITLE
Moving wayland variables from shell configs to /etc/profile.d/cachyos-wayland.sh

### DIFF
--- a/etc/profile.d/cachyos-wayland.sh
+++ b/etc/profile.d/cachyos-wayland.sh
@@ -1,0 +1,12 @@
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    export WAYLAND=1
+    export QT_QPA_PLATFORM='wayland;xcb'
+    export GDK_BACKEND='wayland,x11'
+    export MOZ_DBUS_REMOTE=1
+    export MOZ_ENABLE_WAYLAND=1
+    export _JAVA_AWT_WM_NONREPARENTING=1
+    export BEMENU_BACKEND=wayland
+    export CLUTTER_BACKEND=wayland
+    export ECORE_EVAS_ENGINE=wayland_egl
+    export ELM_ENGINE=wayland_egl
+fi


### PR DESCRIPTION
Greetings!

I propose to move the variables for Wayland to profile.d so that they work regardless of the default command line shell. Also, profile.d itself will allow you to make interesting tweaks to the system's variables.

A little later I will make pull requests for the zsh and fish settings, mentioning this pull request