### PR TITLE
pci-latency: Replace grep with the lspci device filter by class

### DIFF
--- a/usr/bin/pci-latency
+++ b/usr/bin/pci-latency
@@ -8,7 +8,7 @@ sudo setpci -v -s '*:*' latency_timer=20
 sudo setpci -v -s '0:0' latency_timer=0
 
 # Find all sound cards
-SOUND_CARDS=$(lspci | grep -i audio | cut -d " " -f 1)
+SOUND_CARDS=$(lspci -nd "*:*:04xx" | cut -d " " -f 1)
 
 # Loop through sound cards and set latency timer to 80
 for CARD in $SOUND_CARDS; do


### PR DESCRIPTION
Just worried about possible errors because of grep