### PR TITLE
sysctl: Disable split_lock_mitigate by default

### DIFF
--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -134,3 +134,7 @@ kernel.sched_pelt_multiplier = 2
 # Increase the sched_rt_runtime_us to mitigate issues:
 # sched: RT throttling activated
 kernel.sched_rt_runtime_us=980000
+
+# These mitigations can lead to very low performance of some Windows games
+# (e.g. God of War), 0 will disable spamming logs about using split locks.
+kernel.split_lock_mitigate = 0


### PR DESCRIPTION
Since 6.2 this behavior can be controlled via sysctl instead of a kernel parameter, so use that, although it will not work for LTS.

See also: https://www.phoronix.com/news/Linux-Splitlock-Hurts-Gaming