### PR TITLE
sysctl: Increase swappiness to 100

### DIFF
--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -1,6 +1,7 @@
-# The swappiness sysctl parameter represents the kernel's preference (or avoidance) of swap space. Swappiness can have a value between 0 and 100, the default value is 60. 
-# A low value causes the kernel to avoid swapping, a higher value causes the kernel to try to use swap space. Using a low value on sufficient memory is known to improve responsiveness on many systems.
-vm.swappiness = 30
+# The sysctl swappiness parameter determines the kernel's preference for pushing anonymous pages or page cache to disk in memory-starved situations.
+# A low value causes the kernel to prefer freeing up open files (page cache), a high value causes the kernel to try to use swap space,
+# and a value of 100 means IO cost is assumed to be equal.
+vm.swappiness = 100
 
 # The value controls the tendency of the kernel to reclaim the memory which is used for caching of directory and inode objects (VFS cache). 
 # Lowering it from the default value of 100 makes the kernel less inclined to reclaim VFS cache (do not set it to 0, this may produce out-of-memory conditions)


### PR DESCRIPTION
Okay, let me try to explain why. The point is that since kernel version 5.8 the behavior of the kernel with respect to `vm.swappiness` has changed [1][2]. First, `vm.swappienss` no longer controls or sets a threshold for when swap starts to be used.  Now the parameter vm.swappiness is a kind of "scales", depending on which way it is tilted, the kernel will prefer to free a certain type of pages [3][4]. A value between 0 and 200 means that the kernel will be the first to dump to disk, page cache or anonymous pages to swap if possible. Low values mean that the kernel will first try to flush the page cache, and only then anonymous pages to the swap. High values mean swap first. A value of 100 means balance, i.e. the kernel will equally try to flush anonymous pages and page cache to disk at the same time, which also means the same cost on the I/O.

The reason we have to set 100 is because:

1. If we use low values, it will not bring much I/O load reduction, because the kernel will just switch to aggressive flushing the page cache.
2. Most Linux distributions have long used zswap by default, which helps reduce I/O load by introducing a preliminary "buffer" for pages that should go into swap. In Arch/CachyOS we have it by default too, so it should be some sort of cushion for swap when used on HDD.
3. It also makes sense to use high values for ZRAM, since the swap is in RAM, it would be better if it aggressively compresses all anonymous pages in case of RAM shortage, than trying to flush the page cache.

If my explanation wasn't too lucid, I think this article makes a lot of sense to mention:
https://www.howtogeek.com/449691/what-is-swapiness-on-linux-and-how-to-change-it/

[1] - https://github.com/torvalds/linux/commit/c843966c556d7370bb32e7319a6d164cb8c70ae2
[2] - https://github.com/torvalds/linux/commit/314b57fb0460001a090b35ff8be987f2c868ad3c
[3] - https://wiki.archlinux.org/index.php?title=Swap&type=revision&diff=776337&oldid=768280
[4] - https://wiki.gentoo.org/index.php?title=Swap&type=revision&diff=1160579&oldid=1160531

I also attach my personal swap tests on a laptop with 4gb and set vm.swappiness = 100. As you can see, swap usage is not as aggressive as one would assume.
![7279dc6d-d8b8-4120-ae77-e8a7b04069d6](https://user-images.githubusercontent.com/92667539/235295844-141401e4-febb-4390-9a18-7fc0a0052d5d.png)
