### PR TITLE
Clean up sysctl

### DIFF
--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -63,22 +63,6 @@ kernel.kexec_load_disabled = 1
 # The upper limit on how many connections the kernel will accept (default 128): 
 net.core.somaxconn = 8192
 
-# Increase the memory dedicated to the network interfaces
-# The default the Linux network stack is not configured for high speed large file transfer across WAN links (i.e. handle more network packets) and setting the correct values may save memory resources: 
-# cloudflare tcp collapse patch included in the cachyos kernel
-net.core.rmem_default = 1048576
-net.core.rmem_max = 16777216
-net.core.wmem_default = 1048576
-net.core.wmem_max = 16777216
-net.core.optmem_max = 65536
-net.ipv4.tcp_rmem = 8192 262144 536870912
-net.ipv4.tcp_wmem = 4096 16384 536870912
-net.ipv4.tcp_adv_win_scale = -2
-net.ipv4.tcp_collapse_max_bytes = 6291456
-net.ipv4.tcp_notsent_lowat = 131072
-net.ipv4.udp_rmem_min = 8192
-net.ipv4.udp_wmem_min = 8192
-
 # Enable TCP Fast Open
 # TCP Fast Open is an extension to the transmission control protocol (TCP) that helps reduce network latency
 # by enabling data to be exchanged during the sender’s initial TCP SYN [3]. 

--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -10,7 +10,7 @@ vm.swappiness = 100
 # Contains, as a percentage of total available memory that contains free pages and reclaimable
 # pages, the number of pages at which a process which is generating disk writes will itself start
 # writing out dirty data (Default is 20).
-vm.dirty_ratio = 3
+vm.dirty_ratio = 8
 
 # page-cluster controls the number of pages up to which consecutive pages are read in from swap in a single attempt. 
 # This is the swap counterpart to page cache readahead. The mentioned consecutivity is not in terms of virtual/physical addresses, 
@@ -21,7 +21,7 @@ vm.page-cluster = 0
 # Contains, as a percentage of total available memory that contains free pages and reclaimable
 # pages, the number of pages at which the background kernel flusher threads will start writing out
 # dirty data (Default is 10).
-vm.dirty_background_ratio = 5
+vm.dirty_background_ratio = 4
 
 # This tunable is used to define when dirty data is old enough to be eligible for writeout by the
 # kernel flusher threads.  It is expressed in 100'ths of a second.  Data which has been dirty

--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -50,9 +50,6 @@ kernel.unprivileged_userns_clone = 1
 # To hide any kernel messages from the console
 kernel.printk = 3 3 3 3
 
-# Restricting access to kernel logs
-kernel.dmesg_restrict = 1
-
 # Restricting access to kernel pointers in the proc filesystem
 kernel.kptr_restrict = 2
 


### PR DESCRIPTION
The settings for the network can be reviewed and returned. But for now, they will be removed.

Also note what the Arch Wiki says about these settings:
> This section seems motivated by the Cloudflare blog post, but Red Hat's tuned profile suggests even smaller values and claims "this seems only necessary at 40Gb speeds". Hence, these settings do not seem useful for commodity hardware.

https://wiki.archlinux.org/title/Sysctl#Increase_the_memory_dedicated_to_the_network_interfaces
https://github.com/redhat-performance/tuned/blob/master/profiles/network-throughput/tuned.conf#L10

I also have some doubts about the current values of dirty_ratio.