### PR TITLE
sysctl: Make the value of dirty pages optimal and for most configurat…

### DIFF
--- a/etc/sysctl.d/99-cachyos-settings.conf
+++ b/etc/sysctl.d/99-cachyos-settings.conf
@@ -9,8 +9,8 @@ vm.swappiness = 100
 
 # Contains, as a bytes of total available memory that contains free pages and reclaimable
 # pages, the number of pages at which a process which is generating disk writes will itself start
-# writing out dirty data (Default is 20).
-vm.dirty_bytes = 1073741824
+# writing out dirty data.
+vm.dirty_bytes = 268435456
 
 # page-cluster controls the number of pages up to which consecutive pages are read in from swap in a single attempt. 
 # This is the swap counterpart to page cache readahead. The mentioned consecutivity is not in terms of virtual/physical addresses, 
@@ -20,8 +20,8 @@ vm.page-cluster = 0
 
 # Contains, as a bytes of total available memory that contains free pages and reclaimable
 # pages, the number of pages at which the background kernel flusher threads will start writing out
-# dirty data
-vm.dirty_background_bytes = 268435456
+# dirty data.
+vm.dirty_background_bytes = 134217728
 
 # This tunable is used to define when dirty data is old enough to be eligible for writeout by the
 # kernel flusher threads.  It is expressed in 100'ths of a second.  Data which has been dirty


### PR DESCRIPTION
…ions

Do not touch this until it has been tested.

The main motivation is that I noticed, on my laptop with 16Gb RAM and NVMe, that the dirty pages when simultaneously downloading in Steam and Qbittorrent did not exceed more than one and a half gigabytes. That said, the values used in the ratio are often excessive, and for desktop tasks you just can not have a situation, dirty pages you have more than 2 gigabytes. Because of this, and to avoid problems with ratio value selection for each individual configuration, I suggest replacing ratio by bytes. Otherwise, it requires testing.