### PR TITLE
modprobe.d: Force using of amdgpu driver for older graphics cards by default

### DIFF
--- a/etc/modprobe.d/amdgpu.conf
+++ b/etc/modprobe.d/amdgpu.conf
@@ -3,6 +3,5 @@
 options amdgpu si_support=1
 options amdgpu cik_support=1
 
-# If amdgpu fails to boot, will do fallback on radeon
 options radeon si_support=0
 options radeon cik_support=0

--- a/etc/modprobe.d/amdgpu.conf
+++ b/etc/modprobe.d/amdgpu.conf
@@ -1,0 +1,8 @@
+# Force using of the amdgpu driver for Southern Islands (GCN 1.0+) and Sea
+# Islands (GCN 2.x) generations.
+options amdgpu si_support=1
+options amdgpu cik_support=1
+
+# If amdgpu fails to boot, will do fallback on radeon
+options radeon si_support=0
+options radeon cik_support=0


### PR DESCRIPTION
We have already received a lot of issues from users about Vulkan not working on old AMD cards due to lack of amdgpu driver. I think it makes sense to force its use by default, since users will want to do it anyway and our kernel supports this feature. 

Refs:
https://wiki.archlinux.org/title/AMDGPU#Enable_Southern_Islands_(SI)_and_Sea_Islands_(CIK)_support
https://github.com/ValveSoftware/Proton/wiki/For-AMD-users-having-issues-with-non-OpenGL-games
https://gitlab.freedesktop.org/drm/amd/-/issues/1776
