### PR TITLE
udev: Tune ZRAM rules for better performance

### DIFF
--- a/etc/udev/rules.d/30-zram.rules
+++ b/etc/udev/rules.d/30-zram.rules
@@ -1,9 +1,21 @@
+# Prefer to recompress only idle pages. This will result in additional memory
+# savings, but may slightly increase CPU load due to additional compression
+# overhead.
 ACTION=="add", KERNEL=="zram[0-9]*", ATTR{recomp_algorithm}="algo=lz4 priority=1", \
   RUN+="/sbin/sh -c echo 'type=idle' > /sys/block/%k/recompress"
 
 TEST!="/dev/zram0", GOTO="zram_end"
 
+# Since ZRAM stores all pages in compressed form in RAM, we should prefer
+# preempting anonymous pages more than a page (file) cache.  Preempting file
+# pages may not be desirable because a process may want to access a file at any
+# time, whereas if it is preempted, it will cause an additional read cycle from
+# the disk.
 SYSCTL{vm.swappiness}="150"
+
+# Optimal value for games, so sets not too aggressive, but also not too weak
+# kswapd behavior, as described there:
+# https://www.reddit.com/r/linux_gaming/comments/vla9gd/comment/ie1cnrh/
 SYSCTL{vm.watermark_scale_factor}="125"
 SYSCTL{vm.watermark_boost_factor}="0"
 

--- a/etc/udev/rules.d/30-zram.rules
+++ b/etc/udev/rules.d/30-zram.rules
@@ -1,2 +1,10 @@
-ACTION=="add", KERNEL=="zram[0-9]*", ATTR{recomp_algorithm}=="", ATTR{recomp_algorithm}="algo=lz4 priority=1"
-IMPORT{program}="/sbin/sh -c \"echo \"type=idle\" > /sys/block/zram*/recompress\""
+ACTION=="add", KERNEL=="zram[0-9]*", ATTR{recomp_algorithm}="algo=lz4 priority=1", \
+  RUN+="/sbin/sh -c echo 'type=idle' > /sys/block/%k/recompress"
+
+TEST!="/dev/zram0", GOTO="zram_end"
+
+SYSCTL{vm.swappiness}="150"
+SYSCTL{vm.watermark_scale_factor}="125"
+SYSCTL{vm.watermark_boost_factor}="0"
+
+LABEL="zram_end"


### PR DESCRIPTION
Since we ship zram by default via zram-generator, I think we should do some extra tuning through new ``zramtune`` service.

This service performs:
- Set the ``vm.swappiness`` value to 150. We need to push anonymous pages out more, once they are located in ZRAM.
- Setting idle pages re-compression (we used to have this in an udev rule, but it didn't seem to work properly).
- Set ``vm.watermark_scaling_factor`` parameter as recommended here:
https://www.reddit.com/r/linux_gaming/comments/vla9gd/comment/ie1cnrh/

The list of changes is not too long, but it creates a convenient opportunity to define ZRAM-specific settings later on.