### PR TITLE
Enable defer+madvise defragmention for THP by default

### DIFF
--- a/etc/tmpfiles.d/thp.conf
+++ b/etc/tmpfiles.d/thp.conf
@@ -1,4 +1,3 @@
 # Improve performance for applications that use tcmalloc
 # https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations
 w! /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise
-w! /sys/kernel/mm/transparent_hugepage/enabled - - - - madvise

--- a/etc/tmpfiles.d/thp.conf
+++ b/etc/tmpfiles.d/thp.conf
@@ -1,3 +1,4 @@
 # Improve performance for applications that use tcmalloc
 # https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations
 w- /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise
+w- /sys/kernel/mm/transparent_hugepage/enable - - - - madvise

--- a/etc/tmpfiles.d/thp.conf
+++ b/etc/tmpfiles.d/thp.conf
@@ -1,0 +1,3 @@
+# Improve performance for applications that use tcmalloc
+# https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations
+w- /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise

--- a/etc/tmpfiles.d/thp.conf
+++ b/etc/tmpfiles.d/thp.conf
@@ -1,4 +1,4 @@
 # Improve performance for applications that use tcmalloc
 # https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations
 w! /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise
-w! /sys/kernel/mm/transparent_hugepage/enable - - - - madvise
+w! /sys/kernel/mm/transparent_hugepage/enabled - - - - madvise

--- a/etc/tmpfiles.d/thp.conf
+++ b/etc/tmpfiles.d/thp.conf
@@ -1,4 +1,4 @@
 # Improve performance for applications that use tcmalloc
 # https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations
-w- /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise
-w- /sys/kernel/mm/transparent_hugepage/enable - - - - madvise
+w! /sys/kernel/mm/transparent_hugepage/defrag - - - - defer+madvise
+w! /sys/kernel/mm/transparent_hugepage/enable - - - - madvise


### PR DESCRIPTION
This should improve the performance of applications that use the tcmalloc memory allocator, which is used by Chromium/Electron and Valve's native games, among others.
Ref: https://github.com/google/tcmalloc/blob/master/docs/tuning.md#system-level-optimizations