### PR TITLE
Added wayland variables to profile.d

### DIFF
--- a/etc/profile.d/wayland.sh
+++ b/etc/profile.d/wayland.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
     export WAYLAND=1
-    export QT_QPA_PLATFORM='xcb'
+    export QT_QPA_PLATFORM='wayland;xcb'
     export GDK_BACKEND='wayland,x11'
     export MOZ_DBUS_REMOTE=1
     export MOZ_ENABLE_WAYLAND=1

--- a/etc/profile.d/wayland.sh
+++ b/etc/profile.d/wayland.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+    export WAYLAND=1
+    export QT_QPA_PLATFORM='xcb'
+    export GDK_BACKEND='wayland,x11'
+    export MOZ_DBUS_REMOTE=1
+    export MOZ_ENABLE_WAYLAND=1
+    export _JAVA_AWT_WM_NONREPARENTING=1
+    export BEMENU_BACKEND=wayland
+    export CLUTTER_BACKEND=wayland
+    export ECORE_EVAS_ENGINE=wayland_egl
+    export ELM_ENGINE=wayland_egl
+    export WINIT_UNIX_BACKEND=x11
+    export KITTY_ENABLE_WAYLAND=1
+fi


### PR DESCRIPTION
Greetings!

I decided to do a similar PR again, but now I've delved a little deeper into the topic with variables and how it could be implemented.
In the end, it made sense to enable variables via profile.d, given all its intricacies.

Why didn't I engage the same `systemd-environment-generator`?

- Variables don't work globally

- They are triggered only if the program is run in the terminal

A friend also found a feature that if shebang is added to a script, it will work through profile.d, no matter what shell is used.

Also I want to say an obvious problem - variables for Wayland don't work in `zsh` and `fish` configs, they have a similar problem as `systemd-environment-generator`. 
I have already tested this script in profile.d, and not only on CachyOS, but also on Fedora, Arch, EndeavourOS - it's working properly.