### PR TITLE
Update zram-generator.conf to use LZ4

### DIFF
--- a/etc/systemd/zram-generator.conf
+++ b/etc/systemd/zram-generator.conf
@@ -1,3 +1,3 @@
 [zram0] 
-compression-algorithm = zstd
+compression-algorithm = lz4
 zram-size = ram / 4


### PR DESCRIPTION
LZ4 is what is configured to be used in /etc/udev/rules.d/30-zram.rules so this is just to sync up with that.