### PR TITLE
Do not use performance governor on laptops

### DIFF
--- a/etc/udev/rules.d/10-laptop.rules
+++ b/etc/udev/rules.d/10-laptop.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="power_supply", KERNEL!="hidpp_battery*", RUN+="/usr/bin/laptop-mode"

--- a/usr/bin/laptop-mode
+++ b/usr/bin/laptop-mode
@@ -1,0 +1,28 @@
+#!/bin/bash
+# A script for basic power saving for laptops.
+# Should be called by udev rule.
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This command must be run with root privileges" 1>&2
+    exit 1
+fi
+
+# Quiet redirections
+exec 1> /dev/null
+
+STATE="$(cat /sys/class/power_supply/BAT0/status)"
+
+# Try to do certain things only for laptops with AMD Pstate driver support
+if [ -f /sys/devices/system/cpu/amd_pstate/status ]; then
+
+    ## Set amd-pstate to passive, to enable amd-pstate-epp
+    echo passive | tee /sys/devices/system/cpu/amd_pstate/status
+fi
+
+# Use conversation when laptop is not running on battery power,
+# and powersave when on battery power
+if [ "$STATE" = "Discharging" ]; then
+    echo powersave | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+else
+    echo conservative | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+fi


### PR DESCRIPTION
Many laptop users, complain that their laptop after installing CachyOS warms up a lot, because we supply a performance governor in our kernel by default. I think it's a issues that should be fixed, so that's the PR we're in:

1. Call the laptop-mode script after the udev rule on battery is triggered.
2. The following settings are set inside the script:
   a) On laptops with amd-pstate driver support, we use passive mode. From my side it is far preferable to active or guided as it has a more extensive set of governors. Other users have also commented that it works well on their laptop [1].
   TODO: I haven't figured out what to do with Intel CPUs yet, as I'm not very familiar with how the Intel Pstate driver works.
   b) Set the governor to powersave or conservative depending on whether the laptop is currently charging or not.
   
Why conservative and not on-demand or schedutil? I think it is much better suited for laptops due to the smoother frequency rise. My laptop no longer goes into turbo boost if I open some new application or game. I also noticed that this is the only governor that allows you to set max CPU frequency limit properly. In other words, conservative allows you to deal with problem of trotting on laptops quite effectively, so I prefer it. 

I'm marking this as Draft as it requires a discussion, and besides, I'm also thinking of an alternative solution to this with a TLP ship.

[1] - https://old.reddit.com/r/linux/comments/15p4bfs/amd_pstate_and_amd_pstate_epp_scaling_driver/jvy9jjl/