### PR TITLE
nvidia: Add fbdev=1 as default

### DIFF
--- a/etc/modprobe.d/nvidia.conf
+++ b/etc/modprobe.d/nvidia.conf
@@ -1,2 +1,2 @@
 options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02
-options nvidia_drm modeset=1
+options nvidia_drm modeset=1 fbdev=1


### PR DESCRIPTION
This adds the new nvidia option "fbdev=1" as default for the nvidia module.
This option is required for some nvidia cards to have a proper wayland experience. [1}

On top this provides a framebuffer, which is scaled to the default monitor resolution.

1. https://forums.developer.nvidia.com/t/kde-wayland-doesnt-work-on-the-545-drivers/269794/2