### PR TITLE
io-scheduler: Use kyber for nvme's and ssd's

### DIFF
--- a/etc/udev/rules.d/60-ioschedulers.rules
+++ b/etc/udev/rules.d/60-ioschedulers.rules
@@ -1,6 +1,7 @@
-# set scheduler for NVMe
-ACTION=="add|change", KERNEL=="nvme[0-9]n[0-9]", ATTR{queue/scheduler}="none"
-# set scheduler for SSD and eMMC
-ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
-# set scheduler for rotating disks
-ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
+# BFQ is recommended for slow storage such as rotational block devices and SD cards.
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="mmcblk?", ATTR{queue/scheduler}="bfq"
+
+# Kyber is recommended for faster storage such as NVME and SATA SSDs.
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="0", KERNEL=="nvme?n?", ATTR{queue/scheduler}="kyber"
+ACTION=="add|change", SUBSYSTEM=="block", ATTR{queue/rotational}=="0", KERNEL=="sd?", ATTR{queue/scheduler}="kyber"


### PR DESCRIPTION
I have tested kyber for the nvme in various workloads and it does improve the repressives of the desktop under heavy IO scenarios a lot compared to "none". 

Throughput appears to be lower for around 3% in my testings (tested with kdiskmark).

Also see following:

https://github.com/pop-os/default-settings/pull/149

Fixes: https://github.com/CachyOS/CachyOS-Settings/issues/34
