### PR TITLE
udev: Remove force loading of nvidia modules

### DIFF
--- a/etc/udev/rules.d/71-nvidia.rules
+++ b/etc/udev/rules.d/71-nvidia.rules
@@ -1,15 +1,3 @@
-# Load and unload nvidia-modeset module
-ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe nvidia-modeset"
-ACTION=="remove", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe -r nvidia-modeset"
-
-# Load and unload nvidia-drm module
-ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe nvidia-drm"
-ACTION=="remove", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe -r nvidia-drm"
-
-# Load and unload nvidia-uvm module
-ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe nvidia-uvm"
-ACTION=="remove", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/sbin/modprobe -r nvidia-uvm"
-
 # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
 ACTION=="bind", SUBSYSTEM=="pci", DRIVERS=="nvidia", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
 


### PR DESCRIPTION
It seems to be causing some boot/shutdown issues. Also not sure if they were useful in the current setup 