### PR TITLE
udev/zram: Try to re-compress only uncompressed pages

### DIFF
--- a/etc/udev/rules.d/30-zram.rules
+++ b/etc/udev/rules.d/30-zram.rules
@@ -1,8 +1,8 @@
-# Prefer to recompress only idle pages. This will result in additional memory
+# Prefer to recompress only huge pages. This will result in additional memory
 # savings, but may slightly increase CPU load due to additional compression
 # overhead.
 ACTION=="add", KERNEL=="zram[0-9]*", ATTR{recomp_algorithm}="algo=lz4 priority=1", \
-  RUN+="/sbin/sh -c echo 'type=idle' > /sys/block/%k/recompress"
+  RUN+="/sbin/sh -c echo 'type=huge' > /sys/block/%k/recompress"
 
 TEST!="/dev/zram0", GOTO="zram_end"
 


### PR DESCRIPTION
This reduces CPU overhead while saving memory in the case of pages that could not be compressed by the primary algorithm. This also gets rid of the `CONFIG_ZRAM_MEMORY_TRACKING` dependency for the kernel.

Thanks @firelzrd for the hint.