### PR TITLE
zram-generator: Make ZRAM size equal to RAM

### DIFF
--- a/etc/systemd/zram-generator.conf
+++ b/etc/systemd/zram-generator.conf
@@ -1,3 +1,3 @@
 [zram0] 
 compression-algorithm = zstd
-zram-size = ram / 4
+zram-size = ram


### PR DESCRIPTION
It is important to be aware that the size of ZRAM block device does not reflect the actual size of compressed pages it contains. The ZRAM size is the total number of pages that can be placed in swap as if it were on disk, but if you look through `zramctl` in the `COMPR` column, you can see that actual size has shrunk by a factor of about three (as the kernel developers claim and it's close to the truth). So the larger ZRAM size actually allows for more capacity for compressed pages as well. We also need this because of the high ``vm.swappiness`` value, which forces kernel to push more pages into ZRAM.

Also read on arch wiki about that: https://wiki.archlinux.org/title/Zram#Usage_as_swap