### PR TITLE
Use X11 rootless by default for SDDM

### DIFF
--- a/etc/sddm.conf.d/rootless-x11.conf
+++ b/etc/sddm.conf.d/rootless-x11.conf
@@ -1,0 +1,2 @@
+[General]
+DisplayServer=x11-user


### PR DESCRIPTION
For security purposes and to avoid issues with complete system hangs when missing modules/other situations.