### PR TITLE
udev/ioschedulers: Use mq-deadline for SSD/SD cards

### DIFF
--- a/etc/udev/rules.d/60-ioschedulers.rules
+++ b/etc/udev/rules.d/60-ioschedulers.rules
@@ -2,7 +2,7 @@
 ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
 
 # SSD
-ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", SUBSYSTEMS!="usb", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="mq-deadline"
 
 # NVMe SSD
 ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="none"


### PR DESCRIPTION
BFQ is prone to regressive behavior on SSD/SD cards. Actually, for the SATA SSDs I'm more inclined to use none as well as NVMe, but I'm not sure about that yet.