### PR TITLE
set minimum zram size

### DIFF
--- a/etc/systemd/zram-generator.conf
+++ b/etc/systemd/zram-generator.conf
@@ -1,3 +1,3 @@
 [zram0] 
 compression-algorithm = zstd
-zram-size = ram
+zram-size = max(ram, 8192)


### PR DESCRIPTION
I think we can all agree that systems with less than 8GB of RAM need a bigger zram size than the physical RAM total, allowing fallback to disk-based swap space, or they will frequently hit oom or other issues. This bumps the size for them while keeping the same scaling otherwise.