### PR TITLE
Add CachyOS URL to debuginfod

### DIFF
--- a/etc/debuginfod/cachyos.urls
+++ b/etc/debuginfod/cachyos.urls
@@ -1,0 +1,1 @@
+https://debuginfod.cachyos.org


### PR DESCRIPTION
Currently debuginfod uses as default the archlinux debuginfod URL, which makes issues when used together with CachyOS. The Archlinux URL is still required, since we dont ship all packages yet.

Fixes: https://github.com/CachyOS/CachyOS-Settings/issues/57