### PR TITLE
Replace uksmd with built-in KSM support in systemd 

### DIFF
--- a/usr/bin/ksmctl
+++ b/usr/bin/ksmctl
@@ -53,5 +53,5 @@ else
 fi
 
 if [ -n "$save" ]; then
-    echo "/sys/kernel/mm/ksm/run - - - - $new_state" > "$conf_path"
+    echo "w! /sys/kernel/mm/ksm/run - - - - $new_state" > "$conf_path"
 fi

--- a/usr/bin/ksmctl
+++ b/usr/bin/ksmctl
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Error: This script must be run with root privileges."
+  exit 1
+fi
+
+file_path="/sys/kernel/mm/ksm/run"
+conf_path="/etc/tmpfiles.d/ksm.conf"
+save="y"
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 [--unsave|-u] [--enable|-e|--disable|-d]"
+  echo "  --enable , -e :  Enable KSM"
+  echo "  --disable, -d : Disable KSM"
+  echo "  --unsave, -u : Do not save choice to config files"
+  exit 1
+fi
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --enable | -e)
+        new_state="1"
+        shift
+        ;;
+      --disable | -d)
+        new_state="0"
+        shift
+        ;;
+      -u | --unsave)
+        unset save
+        shift
+        ;;
+      *)
+        echo "Error: Invalid argument. Use --enable, -e, --disable, or -d." >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "$new_state" ]; then
+    echo "Error: Missing action. Use --enable, -e, --disable, or -d." >&2
+    exit 1
+fi
+
+if [ "$new_state" -gt 0 ]; then
+    echo "Enabling Kernel Samepage Merging..."
+    echo "1" > "$file_path"
+else
+    echo "Disabling Kernel Samepage Merging..."
+    echo "2" > "$file_path"
+
+fi
+
+if [ -n "$save" ]; then
+    echo "/sys/kernel/mm/ksm/run - - - - $new_state" > "$conf_path"
+fi

--- a/usr/bin/ksmctl
+++ b/usr/bin/ksmctl
@@ -10,7 +10,7 @@ conf_path="/etc/tmpfiles.d/ksm.conf"
 save="y"
 
 if [ "$#" -eq 0 ]; then
-  echo "Usage: $0 [--unsave|-u] [--enable|-e|--disable|-d]"
+  echo "Usage: $0 [--unsave|-u] {--enable|-e|--disable|-d}"
   echo "  --enable , -e :  Enable KSM"
   echo "  --disable, -d : Disable KSM"
   echo "  --unsave, -u : Do not save choice to config files"

--- a/usr/lib/systemd/system/gdm.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/gdm.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/systemd/system/getty@.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/getty@.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/systemd/system/lightdm.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/lightdm.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/systemd/system/ly.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/ly.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/systemd/system/sddm.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/sddm.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/systemd/system/user@.service.d/10-ksm.conf
+++ b/usr/lib/systemd/system/user@.service.d/10-ksm.conf
@@ -1,0 +1,2 @@
+[Service]
+MemoryKSM=yes

--- a/usr/lib/tmpfiles.d/ksm.conf
+++ b/usr/lib/tmpfiles.d/ksm.conf
@@ -1,0 +1,3 @@
+# Enables ksmd to run on on processes spawned from services
+# with MemoryKSM=yes enabled
+w! /sys/kernel/mm/ksm/run - - - - 1


### PR DESCRIPTION
systemd allows to use the same mechanism (kernel API) as uksmd using the `MemoryKSM=yes` service option. The idea is that we take the processes that are parent to most user processes like display managers (SDDM/GDM/LightMD/Ly/etc) or getty in case we don't have a display manager, and enable `MemoryKSM=yes` for them, so that all child processes inherit the PR_SET_MEMORY_MERGE attribute, which gives ksmd a hint that the pages of this process can be merged. Unlike uksmd it allows us to: 
1) Don't waste a lot of unnecessary CPU time for tracking down new processes.
2) No need for additional kernel patches that will probably never be accepted in upstream.
3) Avoid depending on extra services/packages which may be undesirable for some users (see https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/203)
4) For some users uksmd causes freezes (see https://github.com/CachyOS/uksmd/issues/5).

I also put a new `ksmctl` utility in these patches that allows you to disable ksmd right at runtime, in case debugging/regressions occur. Measurements and profits can be retrieved using `topmem --sort ksm`.

Marked as a draft until systemd 256 is available in the repo, as it contains an important fix related to these changes.