### PR TITLE
Add helper script to set powerprofiles to performance

### DIFF
--- a/usr/bin/game-performance
+++ b/usr/bin/game-performance
@@ -1,4 +1,5 @@
 #!/bin/bash
 # Helper script to enable the performance gov with proton or others
 
-powerprofilesctl set performance
+# set performance governors, as long the game is launched
+powerprofilesctl launch -p performance -r "Launched with CachyOS game-performance utility" "$@"

--- a/usr/bin/game-performance
+++ b/usr/bin/game-performance
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Helper script to enable the performance gov with proton or others
+
+powerprofilesctl set performance


### PR DESCRIPTION
CachyOS does not use Gamemode as default, which makes it a bit harder to switch to the performance governor.

Lets provide a script, which simply utilizes power-profiles-daemon to switch to the performance mode.

User can add to the Game Launch Options:

`game-performance %command% `

todo:

Make it maybe reset, when game does stop