### PR TITLE
Revert "nvidia.conf: Enable GSP again"

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -24,5 +24,5 @@
 # as the framebuffer is handled by the iGPU. This parameter is marked as
 # experimental, so bugs may occur.
 #
-options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02
+options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02 NVreg_EnableGpuFirmware=0
 options nvidia_drm modeset=1 fbdev=1


### PR DESCRIPTION
Hello there,

The nvidia-dkms 555.58.02-1 still does not completely fix the issues with the GSP firmware. There are still minor stutters on the Plasma desktop. Additionally, enabling V-Sync in Minecraft causes the FPS to drop from a stable 144 FPS to 93 FPS. Without GSP Firmware enabled it remains at 144 FPS with no stuttering.