### PR TITLE
Drop limits

### DIFF
--- a/etc/security/limits.d/99-audio.conf
+++ b/etc/security/limits.d/99-audio.conf
@@ -1,2 +1,0 @@
-@audio - rtprio 99
-@audio - memlock unlimited

--- a/etc/security/limits.d/99-esync.conf
+++ b/etc/security/limits.d/99-esync.conf
@@ -1,1 +1,0 @@
-* hard nofile 2097152

--- a/etc/security/limits.d/99-realtime.conf
+++ b/etc/security/limits.d/99-realtime.conf
@@ -1,2 +1,0 @@
-@realtime - rtprio 99
-@realtime - memlock unlimited


### PR DESCRIPTION
This is handled by realtime-privileges and rtkit already. Also, ulimit -l reports to be unlimited, which should be not done due security concerns.