### PR TITLE
feat: add sbctl-sign-batch for secure boot

### DIFF
--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# sbctl-batch-sign is a helper script designed to make it easier for users to sign files needed for secure boot support.
+# The obvious case in which this script helps a lot is when dual booting Windows as there are a lot of files by Windows that
+# needs to be signed in EFI.
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Error: This script must be run with root privileges."
+  exit 1
+fi
+
+if [ "$#" -eq 0 ]; then
+    for entries in $(sbctl verify | grep signed | cut -d' ' -f2); do
+        sbctl sign -s $entries
+    done
+fi


### PR DESCRIPTION
sbctl-batch-sign is a helper script designed to make it easier for users to sign files needed for secure boot support. The obvious case in which this script helps a lot is when dual booting Windows as there are a lot of files by Windows that needs to be signed in EFI.

Windows files in EFI that needs to be signed:
![image](https://github.com/user-attachments/assets/cca02cd9-0c28-460e-b2df-87c8be643247)

To be merged with https://github.com/CachyOS/wiki/pull/42
