### PR TITLE
sysctl.d: Leave core dumps creating enabled by default

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -94,11 +94,6 @@ fs.file-max = 2097152
 # Increase writeback interval  for xfs
 fs.xfs.xfssyncd_centisecs = 10000
 
-# Disable core dumps
-kernel.core_pattern = /dev/null
-# Uncomment the line below and comment the line above to enable core dumps
-# kernel.core_pattern = /usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h
-
 # Only experimental!
 # Let Realtime tasks run as long they need
 # sched: RT throttling activated

--- a/usr/lib/tmpfiles.d/coredump.conf
+++ b/usr/lib/tmpfiles.d/coredump.conf
@@ -1,0 +1,2 @@
+# Clear all coredumps that were created more than 3 days ago
+d /var/lib/systemd/coredump 0755 root root 3d


### PR DESCRIPTION
And also configure cleanup for dumps created more than 3 days ago to save disk space (systemd default is 2 weeks).