### PR TITLE
networkmanager: use systemd-resolved as default dns resolver

### DIFF
--- a/usr/lib/NetworkManager/conf.d/dns.conf
+++ b/usr/lib/NetworkManager/conf.d/dns.conf
@@ -1,0 +1,2 @@
+[main]
+dns=systemd-resolved


### PR DESCRIPTION
implements config changes required for https://github.com/CachyOS/CachyOS-Settings/issues/79