### PR TITLE
sbctl-batch-sign: Add workaround for /boot and /boot/efi partitioned systems

### DIFF
--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -10,7 +10,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 if [ "$#" -eq 0 ]; then
-    for entries in $(sbctl verify | grep signed | cut -d' ' -f2); do
+    for entries in $(sort -u -i <(sbctl verify | grep 'signed' | cut -d' ' -f2) -i <(find /boot -maxdepth 1 -type f | grep vmlinuz)); do
         sbctl sign -s $entries
     done
 fi


### PR DESCRIPTION
When using GRUB or rEFInd, sometimes the kernel images that live in `/boot` does not get detected by `sbctl` because `sbctl` is only scanning for the EFI partition `/boot/efi`. This may be a limitation in sbctl itself or something with how we partition our installs and needs to be investigated further. 

- [x] Draft because I need to remove duplicate entries but it should be an adequate solution, just not elegant.