### PR TITLE
Add workaround for GNOME Wayland crashes

### DIFF
--- a/usr/lib/environment.d/gnome.conf
+++ b/usr/lib/environment.d/gnome.conf
@@ -1,0 +1,2 @@
+# Should be revised after the release of GNOME 47
+MUTTER_DEBUG_KMS_THREAD_TYPE=user


### PR DESCRIPTION
Related with many upstream issues:
https://gitlab.gnome.org/GNOME/mutter/-/issues/3450
https://gitlab.gnome.org/GNOME/mutter/-/issues/3358
https://bbs.archlinux.org/viewtopic.php?id=289584
https://discourse.gnome.org/t/gnome-shell-getting-killed-with-no-coredump-artifacting-with-workaround-fix/22828