### PR TITLE
udev/sata: Check for presence of power management policy attribute

### DIFF
--- a/usr/lib/udev/rules.d/50-sata.rules
+++ b/usr/lib/udev/rules.d/50-sata.rules
@@ -1,3 +1,2 @@
 # SATA Active Link Power Management
-
-ACTION=="add", SUBSYSTEM=="scsi_host", KERNEL=="host*", ATTR{link_power_management_policy}="max_performance"
+ACTION=="add", SUBSYSTEM=="scsi_host", KERNEL=="host*", ATTR{link_power_management_policy}=="*", ATTR{link_power_management_policy}="max_performance"


### PR DESCRIPTION
For some removable devices link_power_management_policy cannot be changed, causing some annoying errors in logs.