### PR TITLE
nvidia-application-profiles: Add profile to avoid aggressive vram usage

### DIFF
--- a/etc/nvidia/nvidia-application-profiles-rc.d/limit-vram-buffer
+++ b/etc/nvidia/nvidia-application-profiles-rc.d/limit-vram-buffer
@@ -1,0 +1,22 @@
+{
+    "rules": [
+        {
+            "pattern": {
+                "feature": "procname",
+                "matches": "kwin_wayland"
+            },
+            "profile": "Limit Free Buffer Pool On Wayland Compositors"
+        }
+    ],
+    "profiles": [
+        {
+            "name": "Limit Free Buffer Pool On Wayland Compositors",
+            "settings": [
+                {
+                    "key": "GLVidHeapReuseRatio",
+                    "value": 1
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Currently the VRAM buffer can be pretty fast bloated, due a bug in the driver.

Avoid this issue with setting an application profile. This has been suggested by a NVIDIA Developer, see below:

https://github.com/NVIDIA/egl-wayland/issues/126#issuecomment-2379945259