### PR TITLE
Audio quality and power states

### DIFF
--- a/usr/lib/modprobe.d/audio.conf
+++ b/usr/lib/modprobe.d/audio.conf
@@ -1,0 +1,2 @@
+options snd_hda_intel power_save=0
+options snd_hda_intel power_save_controller=N

--- a/usr/share/pipewire/pipewire.conf.d/15-resample.conf
+++ b/usr/share/pipewire/pipewire.conf.d/15-resample.conf
@@ -1,0 +1,3 @@
+stream.properties = {
+  resample.quality = 10
+}

--- a/usr/share/wireplumber/wireplumber.conf.d/51-disable-suspension.conf
+++ b/usr/share/wireplumber/wireplumber.conf.d/51-disable-suspension.conf
@@ -1,0 +1,34 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_input.*"
+      },
+      {
+        node.name = "~alsa_output.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]
+monitor.bluez.rules = [
+  {
+    matches = [
+      {
+        node.name = "~bluez_input.*"
+      },
+      {
+        node.name = "~bluez_output.*"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]


### PR DESCRIPTION
There is a setting to improve audio quality and the rest are to disable suspend / power save states.

Disabling those, can help avoid pop, crackling, and any sort of distortions.