### PR TITLE
udev additional rules

### DIFF
--- a/usr/lib/udev/rules.d/50-disable-apst.rules
+++ b/usr/lib/udev/rules.d/50-disable-apst.rules
@@ -1,0 +1,5 @@
+# Disable APST Power Management
+# Fix / Prevent freeze in the system
+# Same as nvme_core.default_ps_max_latency_us=0 in the kernel boot line
+# /sys/block/nvme*/device/power/pm_qos_latency_tolerance_us
+ACTION=="add|change", KERNEL=="nvme[0-9]*",SUBSYSTEMS=="nvme",ATTR{power/pm_qos_latency_tolerance_us}="0"

--- a/usr/lib/udev/rules.d/50-disable-d3cold.rules
+++ b/usr/lib/udev/rules.d/50-disable-d3cold.rules
@@ -1,0 +1,2 @@
+# Disable D3 power state on NVME
+ACTION=="add|change", SUBSYSTEMS=="pci", DRIVERS=="nvme", TEST=="d3cold_allowed", ATTR{d3cold_allowed}="0"

--- a/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
+++ b/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
@@ -1,0 +1,10 @@
+# Has the same idea as usbcore.autosuspend=-1 and usbcore.autosuspend_delay_ms=-1 where you check on /sys/module/usbcore/parameters/autosuspend but does not seem to have an affect.
+# Change that path only works by adding the key=val above in the kernel boot line.
+
+# https://www.kernel.org/doc/Documentation/usb/power-management.txt
+# An example would be to check values you find on /dev/input/by-id/
+# udevadm info -a -n /dev/input/by-id/YOUR_DEVICE
+ACTION=="add|change", SUBSYSTEMS=="usb", ATTR{power/autosuspend}="-1"
+ACTION=="add|change", SUBSYSTEMS=="usb", ATTR{power/autosuspend_delay_ms}="-1"
+ACTION=="add|change", SUBSYSTEMS=="input", ATTR{power/autosuspend}="-1"
+ACTION=="add|change", SUBSYSTEMS=="input", ATTR{power/autosuspend_delay_ms}="-1"

--- a/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
+++ b/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
@@ -1,5 +1,5 @@
-# Has the same idea as usbcore.autosuspend=-1 and usbcore.autosuspend_delay_ms=-1 where you check on /sys/module/usbcore/parameters/autosuspend but does not seem to have an affect.
-# Change that path only works by adding the key=val above in the kernel boot line.
+# Almost the same as usbcore.autosuspend=-1 and usbcore.autosuspend_delay_ms=-1
+# Difference is that only by applying both commands in the kernel line, that the change will appear here /sys/module/usbcore/parameters/autosuspend
 
 # https://www.kernel.org/doc/Documentation/usb/power-management.txt
 # An example would be to check values you find on /dev/input/by-id/

--- a/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
+++ b/usr/lib/udev/rules.d/50-disable-usb-autosuspend.rules
@@ -4,7 +4,7 @@
 # https://www.kernel.org/doc/Documentation/usb/power-management.txt
 # An example would be to check values you find on /dev/input/by-id/
 # udevadm info -a -n /dev/input/by-id/YOUR_DEVICE
-ACTION=="add|change", SUBSYSTEMS=="usb", ATTR{power/autosuspend}="-1"
-ACTION=="add|change", SUBSYSTEMS=="usb", ATTR{power/autosuspend_delay_ms}="-1"
-ACTION=="add|change", SUBSYSTEMS=="input", ATTR{power/autosuspend}="-1"
-ACTION=="add|change", SUBSYSTEMS=="input", ATTR{power/autosuspend_delay_ms}="-1"
+ACTION=="add|change", SUBSYSTEMS=="usb", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"
+ACTION=="add|change", SUBSYSTEMS=="usb", TEST=="power/autosuspend_delay_ms", ATTR{power/autosuspend_delay_ms}="-1"
+ACTION=="add|change", SUBSYSTEMS=="input", TEST=="power/autosuspend", ATTR{power/autosuspend}="-1"
+ACTION=="add|change", SUBSYSTEMS=="input", TEST=="power/autosuspend_delay_ms", ATTR{power/autosuspend_delay_ms}="-1"


### PR DESCRIPTION
There are two rules added

1- To help avoid freezes in the system on nvmes.
2- Disable usb auto suspend to help prevent problems with usb connections.