### PR TITLE
black / freeze screen on gnome fix

### DIFF
--- a/usr/bin/suspend-gnome-shell.sh
+++ b/usr/bin/suspend-gnome-shell.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+case "$1" in
+    suspend)
+        killall -STOP gnome-shell
+        ;;
+    resume)
+        killall -CONT gnome-shell
+        ;;
+esac

--- a/usr/lib/systemd/system/gnome-shell-resume.service
+++ b/usr/lib/systemd/system/gnome-shell-resume.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Resume gnome-shell
+After=systemd-suspend.service
+After=systemd-hibernate.service
+After=nvidia-resume.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/suspend-gnome-shell.sh resume
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service

--- a/usr/lib/systemd/system/gnome-shell-suspend.service
+++ b/usr/lib/systemd/system/gnome-shell-suspend.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Suspend gnome-shell
+Before=systemd-suspend.service
+Before=systemd-hibernate.service
+Before=nvidia-suspend.service
+Before=nvidia-hibernate.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sleep 3
+ExecStart=/usr/bin/suspend-gnome-shell.sh suspend
+
+[Install]
+WantedBy=systemd-suspend.service
+WantedBy=systemd-hibernate.service


### PR DESCRIPTION
A solution that fixed a inactivity problem here and it seems to do more than that.

https://discuss.cachyos.org/t/second-monitor-black-screen/3129

https://github.com/robswc/ubuntu-22-nvidia-suspend-fix-script

If anything, should be optional. 

```
systemctl enable gnome-shell-suspend
systemctl enable gnome-shell-resume
```
