### PR TITLE
game-performance: Fix incorrect argument passing

### DIFF
--- a/usr/bin/game-performance
+++ b/usr/bin/game-performance
@@ -7,4 +7,4 @@ if ! powerprofilesctl list | grep -q 'performance:'; then
 fi
 
 # set performance governors, as long the game is launched
-exec powerprofilesctl launch -p performance -r "Launched with CachyOS game-performance utility" "$@"
+exec powerprofilesctl launch -p performance -r "Launched with CachyOS game-performance utility" -- "$@"


### PR DESCRIPTION
Besides, specifying `-p` seems redundant. This is the default performance.