### PR TITLE
[RFC] modprobe.d/nvidia: Disable GSP firmware by default

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -28,5 +28,5 @@
 # as the framebuffer is handled by the iGPU. This parameter is marked as
 # experimental, so bugs may occur.
 #
-options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02
+options nvidia NVreg_UsePageAttributeTable=1 NVreg_InitializeSystemMemoryAllocations=0 NVreg_DynamicPowerManagement=0x02 NVreg_EnableGpuFirmware=0
 options nvidia_drm modeset=1 fbdev=1


### PR DESCRIPTION
Currently, NVIDIA's GSP firmware can be a bit problematic on some systems, causing frequent stutters and performance issues in general. I think it's best
that we disable this by default in our settings to ensure a more convenient user experience. "Convenient" because:
1. We currently install the open kernel modules as the default for all supported GPUs. We can refer to these groups of users with supported GPUs with 'A'.
2. 'A' will most likely switch to the proprietary kernel modules and will want to disable GSP if experiencing performance issues
3. This sort of provides an "auto switcher" of sorts for the GSP firmware, since it can't be disabled with the open modules, i.e. always enabled, and because it's disabled when installing the closed kernel modules.
4. Because of [3], this line in our [wiki](https://wiki.cachyos.org/configuration/general_system_tweaks/#8-nvidia-gsp-firmware) is also easier to do, instead of the previous method where one has to either comment the line in the file or delete the file and regenerate the initramfs.

> It’s generally recommended to test the GSP firmware after each new NVIDIA driver installation.


From a development standpoint, this seems like a bad thing because we are straying from upstream defaults. However, we need to consider the standpoint from the
users. The cases where GSP firmware has caused problems are not few (as far as I'm aware), and I think this should be a good compromise until it matures more.

Everyone is free to comment on this PR to gather opinions from everyone on what is best to ship with. (users please comment too on your experience with NVIDIA's GSP firmware)