### PR TITLE
tmpfiles.d: Add thp-shrinker config to reduce memory usage

### DIFF
--- a/usr/lib/tmpfiles.d/thp-shrinker.conf
+++ b/usr/lib/tmpfiles.d/thp-shrinker.conf
@@ -1,0 +1,6 @@
+# THP Shrinker has been added in the 6.12 Kernel
+# Default Value is 511
+# THP=always policy vastly overprovisions THPs in sparsely accessed memory areas, resulting in excessive memory pressure and premature OOM killing
+# 409 means that any THP that has more than 409 out of 512 (80%) zero filled filled pages will be split.
+# This reduces the memory usage, when THP=always used and the memory usage goes down to around the same usage as when madivise is used, while still providing equal performance improvement
+w! /sys/kernel/mm/transparent_hugepage/khugepaged/max_ptes_none - - - - 409


### PR DESCRIPTION
Using the always mode (which is default in Archlinux and CachyOS) provides a quite big performance improvement compared to madvise, but this comes with an increased memory usage.

Recently META has contributed the THP Shrinker, which allows to split pages which are underutilized. This can reduce the used memory usage, while providing mostly the same performance improvement.

409 is the provide value by META and we might want to search for more suited values on the desktop. Also, we should do some benchmarks (cachyos-benchmarker) to see if there is a massive difference between 509 and 411.

https://lore.kernel.org/lkml/20240830100438.3623486-1-usamaarif642@gmail.com/