### PR TITLE
sysctl.d/cachyos-settings: Remove kernel.sched_rt_runtime_us

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -93,8 +93,3 @@ fs.file-max = 2097152
 
 # Increase writeback interval  for xfs
 fs.xfs.xfssyncd_centisecs = 10000
-
-# Only experimental!
-# Let Realtime tasks run as long they need
-# sched: RT throttling activated
-kernel.sched_rt_runtime_us=-1


### PR DESCRIPTION
The comments here makes this tunable a bit misleading. Runtime is actually the allocated time from the total period time that is given for RT tasks. A value of -1 indicates that the runtime is equal to the total period, i.e. no limit from total period, and no extra time for non-RT tasks. Reading the documentation[1], it seems that the kernel defaults are favorable compared to what we have right now.

[1] https://github.com/CachyOS/linux/blob/6.12/fixes/Documentation/scheduler/sched-rt-group.rst#21-system-wide-settings