### PR TITLE
sysctl: Network Tunables Cleanup

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -48,7 +48,7 @@ net.ipv4.tcp_ecn = 1
 
 # Increase netdev receive queue
 # May help prevent losing packets
-net.core.netdev_max_backlog = 16384
+net.core.netdev_max_backlog = 4096
 
 # Disable TCP slow start after idle
 # Helps kill persistent single connection performance

--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -52,10 +52,6 @@ net.ipv4.tcp_fastopen = 3
 # TCP Enable ECN Negotiation for both outgoing and incoming connections
 net.ipv4.tcp_ecn = 1
 
-# TCP Reduce performance spikes
-# Refer https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/tuning_guide/reduce_tcp_performance_spikes
-net.ipv4.tcp_timestamps = 0
-
 # Increase netdev receive queue
 # May help prevent losing packets
 net.core.netdev_max_backlog = 16384

--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -43,12 +43,6 @@ kernel.kptr_restrict = 2
 # Disable Kexec, which allows replacing the current running kernel.
 kernel.kexec_load_disabled = 1
 
-# Enable TCP Fast Open
-# TCP Fast Open is an extension to the transmission control protocol (TCP) that helps reduce network latency
-# by enabling data to be exchanged during the sender’s initial TCP SYN [3].
-# Using the value 3 instead of the default 1 allows TCP Fast Open for both incoming and outgoing connections:
-net.ipv4.tcp_fastopen = 3
-
 # TCP Enable ECN Negotiation for both outgoing and incoming connections
 net.ipv4.tcp_ecn = 1
 


### PR DESCRIPTION
There has been reports of slow connection speeds when using CachyOS that are not present when using other distributions. This has been bisected to our sysctl tunables. The other 2 commits serve as a cleanup to:
1. A potential security hazard
2. Keeping saner defaults