### PR TITLE
sysctl: Reduce vm.dirty_background_bytes value

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -21,7 +21,7 @@ vm.page-cluster = 0
 # Contains, as a bytes of total available memory that contains free pages and reclaimable
 # pages, the number of pages at which the background kernel flusher threads will start writing out
 # dirty data.
-vm.dirty_background_bytes = 134217728
+vm.dirty_background_bytes = 67108864
 
 # The kernel flusher threads will periodically wake up and write old data out to disk.  This
 # tunable expresses the interval between those wakeups, in 100'ths of a second (Default is 500).

--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -7,9 +7,8 @@ vm.swappiness = 100
 # Lowering it from the default value of 100 makes the kernel less inclined to reclaim VFS cache (do not set it to 0, this may produce out-of-memory conditions)
 vm.vfs_cache_pressure=50
 
-# Contains, as a bytes of total available memory that contains free pages and reclaimable
-# pages, the number of pages at which a process which is generating disk writes will itself start
-# writing out dirty data.
+# Contains, as bytes, the number of pages at which a process which is
+# generating disk writes will itself start writing out dirty data.
 vm.dirty_bytes = 268435456
 
 # page-cluster controls the number of pages up to which consecutive pages are read in from swap in a single attempt.
@@ -18,9 +17,8 @@ vm.dirty_bytes = 268435456
 # increase this value to 1 or 2 if you are using physical swap (1 if ssd, 2 if hdd)
 vm.page-cluster = 0
 
-# Contains, as a bytes of total available memory that contains free pages and reclaimable
-# pages, the number of pages at which the background kernel flusher threads will start writing out
-# dirty data.
+# Contains, as bytes, the number of pages at which the background kernel
+# flusher threads will start writing out dirty data.
 vm.dirty_background_bytes = 67108864
 
 # The kernel flusher threads will periodically wake up and write old data out to disk.  This


### PR DESCRIPTION
The point is that the greater difference between `vm.dirty_background_bytes` and `vm.dirty_bytes`, the more we avoid possibility of trotting and short I/O pauses for actively writing processes called by the kernel to prevent dirty pages overflows if pdflush doesn't have time to write changes [1]. This is also better from the point of view of data safety, so that it does not stagnate in RAM for too long, as otherwise it risks losing it in case of a power failure or system hang. It is also there now, but at least guarantee that the data loss is not too large.

[1] - https://lwn.net/Articles/456904/