### PR TITLE
udev: Use ntfs3 as the default driver for ntfs partitions

### DIFF
--- a/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
+++ b/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
@@ -1,0 +1,2 @@
+# Mount NTFS partitions as NTFS3 partitions without explicitly specifying NTFS3
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"

--- a/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
+++ b/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
@@ -1,2 +1,2 @@
 # Mount NTFS partitions as NTFS3 partitions without explicitly specifying NTFS3
-SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
+SUBSYSTEM=="block", TEST!="/usr/bin/ntfs-3g", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"


### PR DESCRIPTION
`ntfs` is classified as an unknown filesystem according to Linux and users can't directly mount such partitions directly. Instead, users must explicitly specify the filesystem type, e.g. `mount -t ntfs3 /dev/sdxY /mnt` to mount the partition successfully.

As a QoL change, adding this udev rule can use the `ntfs3` kernel driver by default without explicitly specifying it. Note that this can apparently confuse 3rd party tools and isn't recommended by the Arch wiki. (I'm not entirely sure what this "confusion" is. I guess we would need to have some NTFS users test this.)

Link: https://wiki.archlinux.org/title/NTFS#unknown_filesystem_type_'ntfs'