### PR TITLE
Enable tap to click for X11 sessions by default

### DIFF
--- a/usr/share/X11/xorg.conf.d/20-touchpad.conf
+++ b/usr/share/X11/xorg.conf.d/20-touchpad.conf
@@ -1,0 +1,7 @@
+Section "InputClass"
+     Identifier "libinput touchpad catchall"
+     MatchIsTouchpad "on"
+     MatchDevicePath "/dev/input/event*"
+     Driver "libinput"
+     Option "Tapping" "True"
+EndSection


### PR DESCRIPTION
This is a common issue that users complain about, and I see no reason why it shouldn't be enabled.

If someone for whatever reason needs to disable this, as always they can do so via override files in ``/etc``:
```
sudo ln -s /dev/null /etc/X11/xorg.conf.d/20-touchpad.conf
```


