### PR TITLE
cachyos-bugreport: Include list of installed packages from v3 or v4 repo

### DIFF
--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -47,6 +47,16 @@ EOF
     fi
 }
 
+get_installed_packages() {
+    if [ -e /var/lib/pacman/sync/cachyos-v4.db ]; then
+        pacman -Ss | grep --color=never "^cachyos-v4/.*\[installed\]"
+    elif [ -e /var/lib/pacman/sync/cachyos-v3.db ]; then
+        pacman -Ss | grep --color=never "^cachyos-v3/.*\[installed\]"
+    else
+        echo "v4 nor v3 repositories are not used"
+    fi
+}
+
 bugreport() {
     echo "Starting with bugreport"
 
@@ -82,6 +92,11 @@ journalctl of current boot
 
 $(journalctl -b -p 4..1)
 ____________________________________________
+
+Installed packages
+
+$(get_installed_packages)
+--------------------------------------------
 EOF
 }
 


### PR DESCRIPTION
It is all too common practice to ask about what versions of packages are installed, as this helps to identify packaging issues. To preserve the confidentiality of installed software on the user's system, this PR only exposes information about installed packages from cachyos-v3 or cachyos-v4, which have a limited set of packages but are useful for debugging issues like NVIDIA and mesa drivers, toolchain, compression libraries, etc.