### PR TITLE
fix: sbctl-batch-sign: Better handling of batch file signing by blacklisting known improper PE/COFF executables

### DIFF
--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -12,5 +12,5 @@ fi
 if [ "$#" -eq 0 ]; then
     while IFS= read -r entries; do
         sbctl sign -s $entries
-    done < <(sort -u <(sbctl verify | grep 'signed' | cut -d' ' -f2) <(find /boot -maxdepth 1 -type f | grep vmlinuz))
+    done < <(sort -u <(sbctl verify | grep '✗' | cut -d' ' -f2) <(find /boot -maxdepth 1 -type f | grep vmlinuz))
 fi

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -10,14 +10,21 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 if [ "$#" -eq 0 ]; then
-    while IFS= read -r entries; do
+    sbctl_files="$(sbctl verify | awk '/✗/ {print $2}')"
+    vmlinuz_files="$(find /boot -maxdepth 1 -type f -name "vmlinuz*")"
+    entries=""
+    [[ -n "$sbctl_files" ]] && entries+="$sbctl_files"
+    [[ -n "$sbctl_files" && -n "$vmlinuz_files" ]] && entries+="\n"
+    [[ -n "$vmlinuz_files" ]] && entries+="$vmlinuz_files"
+
+    echo -en "${entries}" | sort -u | while IFS= read -r entry; do
         # We expect users who use this script to enroll their
         # own keys alongside Microsoft's.
         # With that in mind, there's no need to sign MS ESP
         # files with our own keys.
-        if [[ "$entries" =~ ^.*/EFI/(Microsoft|Windows) ]]; then
+        if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) ]]; then
             continue
         fi
-        sbctl sign -s $entries
-    done < <(sort -u <(sbctl verify | awk '/✗/ {print $2}') <(find /boot -maxdepth 1 -type f -name vmlinuz*))
+        sbctl sign -s "$entry"
+    done
 fi

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -10,7 +10,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 if [ "$#" -eq 0 ]; then
-    for entries in $(sort -u -i <(sbctl verify | grep 'signed' | cut -d' ' -f2) -i <(find /boot -maxdepth 1 -type f | grep vmlinuz)); do
+    while IFS= read -r entries; do
         sbctl sign -s $entries
-    done
+    done < <(sort -u <(sbctl verify | grep 'signed' | cut -d' ' -f2) <(find /boot -maxdepth 1 -type f | grep vmlinuz))
 fi

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -12,5 +12,5 @@ fi
 if [ "$#" -eq 0 ]; then
     while IFS= read -r entries; do
         sbctl sign -s $entries
-    done < <(sort -u <(sbctl verify | grep '✗' | cut -d' ' -f2) <(find /boot -maxdepth 1 -type f | grep vmlinuz))
+    done < <(sort -u <(sbctl verify | awk '/✗/ {print $2}') <(find /boot -maxdepth 1 -type f -name vmlinuz*))
 fi

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -22,7 +22,7 @@ if [ "$#" -eq 0 ]; then
         # own keys alongside Microsoft's.
         # With that in mind, there's no need to sign MS ESP
         # files with our own keys.
-        if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) ]]; then
+        if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) || "$entry" == *.mui || "$entry" == *.dll ]]; then
             continue
         fi
         sbctl sign -s "$entry"

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -11,6 +11,13 @@ fi
 
 if [ "$#" -eq 0 ]; then
     while IFS= read -r entries; do
+        # We expect users who use this script to enroll their
+        # own keys alongside Microsoft's.
+        # With that in mind, there's no need to sign MS ESP
+        # files with our own keys.
+        if [[ "$entries" =~ ^.*/EFI/(Microsoft|Windows) ]]; then
+            continue
+        fi
         sbctl sign -s $entries
     done < <(sort -u <(sbctl verify | awk '/✗/ {print $2}') <(find /boot -maxdepth 1 -type f -name vmlinuz*))
 fi


### PR DESCRIPTION
Unfortunately, the prior version of the script caused massive issues for upstream[1][2] due to being poorly written and without any safeguards (mostly due to *a lot* of assumptions). The script is now hopefully better implemented due better protect against these issues by:
1. Actually filtering for unsigned files only this time; see  6d49e37ab94871cce421f9f508bce91f6027664f
2. Ignore ESP files from Microsoft and known files that are not proper PE executables; see 070ff71c21ec519aa97f76a7bc55506e3b9e9680 and eb4baca3911bc0fcac81e89e36ad6f8831e14d28
3. Protect against weird edgecases which may occur from the script due to empty output from either `sbctl` or `find`, and hypothetical filenames with spaces.

[1] https://github.com/Foxboron/sbctl/issues/414
[2] https://github.com/Foxboron/sbctl/issues/376