### PR TITLE
sbctl-batch-sign: Export ESP_PATH and replace find workaround

### DIFF
--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -17,7 +17,8 @@ if [ "$#" -eq 0 ]; then
         # own keys alongside Microsoft's.
         # With that in mind, there's no need to sign MS ESP
         # files with our own keys.
-        if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) || "$entry" == *.mui || "$entry" == *.dll ]]; then
+        if [[ "$entry" =~ ^.*/EFI/(Microsoft|Windows) || "$entry" == *.mui || "$entry" == *.dll
+            || "$entry" =~ ^/boot/grub ]]; then
             continue
         fi
         sbctl sign -s "$entry"

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -3,6 +3,7 @@
 # sbctl-batch-sign is a helper script designed to make it easier for users to sign files needed for secure boot support.
 # The obvious case in which this script helps a lot is when dual booting Windows as there are a lot of files by Windows that
 # needs to be signed in EFI.
+set -e
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "Error: This script must be run with root privileges."

--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -10,14 +10,9 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 if [ "$#" -eq 0 ]; then
-    sbctl_files="$(sbctl verify 2>/dev/null | awk '/✗/ {print $2}')"
-    vmlinuz_files="$(find /boot -maxdepth 1 -type f -name "vmlinuz*" 2>/dev/null)"
-    entries=""
-    [[ -n "$sbctl_files" ]] && entries+="$sbctl_files"
-    [[ -n "$sbctl_files" && -n "$vmlinuz_files" ]] && entries+="\n"
-    [[ -n "$vmlinuz_files" ]] && entries+="$vmlinuz_files"
+    export ESP_PATH=/boot
 
-    echo -en "${entries}" | sort -u | while IFS= read -r entry; do
+    sbctl verify 2>/dev/null | awk '/✗/ {print $2}' | while IFS= read -r entry; do
         # We expect users who use this script to enroll their
         # own keys alongside Microsoft's.
         # With that in mind, there's no need to sign MS ESP


### PR DESCRIPTION
Exporting this variable effectively gives us the same functionality as was given with the find workaround,
with the extra works that the listed files are actually ESP files, as validated by sbctl.

This removes the variable olympics we were doing as to not pass bogus lists to sbctl when signing.

This workaround is mainly for GRUB installs and old rEFInd installs. systemd-boot installs and new-ish rEFInd
installs (post partition table changes) won't need this workaround, and functionality remains the same there.

Unfortunately, this will break weird installs that have weird paths set as their ESP, e.g. /efi. However,
we were already hardcoding /boot in the find workaround anyway, so I'd like to believe that this won't change
anything. CachyOS only supports installs with /boot as their ESP at the moment, and if it ever occurs where
we need to support other ESP paths, we can add a detection for that (or read user input) very easily.

Tested on my CachyOS VM with GRUB boot manager
![image](https://github.com/user-attachments/assets/677a577a-413c-4e68-ac4f-b6a7f0b0136f)