### PR TITLE
sysctl.d: Do not set net.ipv4.tcp_ecn

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -41,9 +41,6 @@ kernel.kptr_restrict = 2
 # Disable Kexec, which allows replacing the current running kernel.
 kernel.kexec_load_disabled = 1
 
-# TCP Enable ECN Negotiation for both outgoing and incoming connections
-net.ipv4.tcp_ecn = 1
-
 # Increase netdev receive queue
 # May help prevent losing packets
 net.core.netdev_max_backlog = 4096


### PR DESCRIPTION
Historically, negotiating ECN for outgoing connections has caused problems. systemd has tried to enable it in the past [1], but it was quickly reverted due to said problems [2]. Now, we got reports of performance issues with webservers and VMs [3]. Let's stick to the defaults with this one

[1] https://github.com/systemd/systemd/commit/919472741dba6ad0a3f6c2b76d390a02d0e2fdc3
[2] https://github.com/systemd/systemd/pull/9880
[3] https://discuss.cachyos.org/t/strange-performance-using-ansible-and-maybe-other-programs/6079