### PR TITLE
udev: Drop ntsync rule, handled now directly by the kernel

### DIFF
--- a/usr/lib/udev/rules.d/99-ntsync.rules
+++ b/usr/lib/udev/rules.d/99-ntsync.rules
@@ -1,1 +1,0 @@
-KERNEL=="ntsync", MODE="0644"


### PR DESCRIPTION
Upstream will add a patch, which makes the module automatically the correct permissions.

This has been applied to the RC (6.14.rc3) and 6.13.3 kernel. As soon they are available we can merge this.