### PR TITLE
systemd: Introduce systemd-oomd conf

### DIFF
--- a/usr/lib/systemd/oomd.conf
+++ b/usr/lib/systemd/oomd.conf
@@ -1,0 +1,17 @@
+[Service]
+ManagedOOMMemoryPressure=kill
+ManagedOOMMemoryPressureLimit=70%
+
+[Slice]
+ManagedOOMSwap=kill
+
+[Manager]
+DefaultCPUAccounting=yes
+DefaultIOAccounting=yes
+DefaultMemoryAccounting=yes
+DefaultTasksAccounting=yes
+
+[OOM]
+SwapUsedLimitPercent=90%
+DefaultMemoryPressureDurationSec=20s
+


### PR DESCRIPTION
oomd.conf define a systemd oomd conf, service can
be enabled manually by user when enable
``` systemctl enable --now systemd-oomd  ```

Based on https://www.reddit.com/r/archlinux/comments/mk2lg6/how_to_properly_configure_systemdoomd/?rdt=56355

Is possible too for separate it in a new package and enable this service in it.
A oomd.conf.d/ can be too prefered if be necessary
