### PR TITLE
dlss: add script to switch to latest dlss preset

### DIFF
--- a/usr/bin/dlss-swapper
+++ b/usr/bin/dlss-swapper
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + updates the dlss dlls via ngx
+
+export PROTON_ENABLE_NGX_UPDATER=1
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+
+# applied variables, now execute the rest of the command
+"$@"

--- a/usr/bin/dlss-swapper
+++ b/usr/bin/dlss-swapper
@@ -10,4 +10,4 @@ export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset
 export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
 
 # applied variables, now execute the rest of the command
-"$@"
+exec "$@"

--- a/usr/bin/dlss-swapper-dll
+++ b/usr/bin/dlss-swapper-dll
@@ -1,0 +1,12 @@
+#!/usr/bin/bash
+
+# This forces Nvidia DLSS to use the latest preset for SR, RR and framegen + skips ngx updater
+
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_FG_OVERRIDE=on
+export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
+
+# applied variables, now execute the rest of the command
+"$@"

--- a/usr/bin/dlss-swapper-dll
+++ b/usr/bin/dlss-swapper-dll
@@ -9,4 +9,4 @@ export DXVK_NVAPI_DRS_NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset
 export DXVK_NVAPI_DRS_NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest
 
 # applied variables, now execute the rest of the command
-"$@"
+exec "$@"


### PR DESCRIPTION
This adds script, which can be used in Steam as launch options.

The `dlss-swapper` does set the dlss preset to the latest available, and also update the dlls via ngx-updater.
NGX Updater is currently not working reliable at all games, and can result into crashes.

The `dlss-swapper-dll` script, only sets the preset to latest. This can be used by users, when they manually switch the dll's in the games directory.
Till ngx updater is working reliable, we likely want to keep the second script too, to make it easier for the user.

Im not sure, how we should call the scripts, so im open for suggestions.

Thanks to @ferrreo for bringing this script up :)