### PR TITLE
nvidia.conf: Enable GSP Firmware again

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,10 +16,6 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
-# NVreg_EnableGpuFirmware=1 (Default 1) - Disables GSP Firmware on NVIDIA's
-# closed source kernel modules. This option is ignored when using NVIDIA's open
-# kernel modules.
-#
 # nvidia_drm.modeset=1 (default 0) - Enables modesetting support for the NVIDIA
 # driver. Critical for Wayland support and proper PRIME Offload operation.
 #

--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,7 +16,7 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
-# NVreg_EnableGpuFirmware=0 (Default 1) - Disables GSP Firmware on NVIDIA's
+# NVreg_EnableGpuFirmware=1 (Default 1) - Disables GSP Firmware on NVIDIA's
 # closed source kernel modules. This option is ignored when using NVIDIA's open
 # kernel modules.
 #
@@ -40,6 +40,5 @@
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
     NVreg_DynamicPowerManagement=0x02 \
-    NVreg_EnableGpuFirmware=0 \
     NVreg_RegistryDwords=RMIntrLockingMode=1
 options nvidia_drm modeset=1


### PR DESCRIPTION
NVIDIA has recently fixed the GSP Firmware stutters and also performance in some scenarios.

Since this is now not anymore a major issue, we should enable the GSP firmware again and following nvidia's defaults.
Users, which might still run into issues can change it manually back.