### PR TITLE
Revert "udev: Use ntfs3 as the default driver for ntfs partitions"

### DIFF
--- a/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
+++ b/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
@@ -1,2 +1,2 @@
 # Mount NTFS partitions as NTFS3 partitions without explicitly specifying NTFS3
-SUBSYSTEM=="block", TEST!="/usr/bin/ntfs-3g", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"

--- a/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
+++ b/usr/lib/udev/rules.d/80-ntfs3-by-default.rules
@@ -1,2 +1,0 @@
-# Mount NTFS partitions as NTFS3 partitions without explicitly specifying NTFS3
-SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="ntfs", ENV{ID_FS_TYPE}="ntfs3"


### PR DESCRIPTION
There has been multiple reports that the ntfs3 kernel driver causes data loss. Revert this until ntfs3 is at
a useable state again. It's better that mounting partitions as `ntfs` doesn't work by default rather than
it mounting but causing irreparable damage in the end.