### PR TITLE
zink-run: Add EGL env for Nvidia compatibility

### DIFF
--- a/usr/bin/zink-run
+++ b/usr/bin/zink-run
@@ -2,4 +2,5 @@
 export MESA_LOADER_DRIVER_OVERRIDE=zink
 export GALLIUM_DRIVER=zink
 export __GLX_VENDOR_LIBRARY_NAME=mesa
+export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
 exec "$@"


### PR DESCRIPTION
`__EGL_VENDOR_LIBRARY_FILENAMES` defaults to `/usr/share/glvnd/egl_vendor.d/10_nvidia.json` on nvidia so it needs to be updated to use mesa for zink to work when using zink with a native wayland program.

`zink-run eglgears_wayland` does not correctly use zink.

`__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json zink-run eglgears_wayland` does correctly use zink.

X11 is a little weirder though because `MANGOHUD=1 zink-run eglgears_x11` does not initialize mangohud like a vulkan program should, but `zink-run mangohud eglgears_x11` does initialize mangohud and mangohud reports that zink is being used but if zink were being used than `mangohud` in the command shouldn't be needed. `zink-run mangohud eglgears_wayland` mangohud reports `OpenGL` unlike eglgears_x11. Both properly initialize mangohud with the mangohud environmental variable and report `ZINK` when `__EGL_VENDOR_LIBRARY_FILENAMES` is set.

glxgears works fine with zink-run as glx env is set.

eglinfo:

```
❯ zink-run eglinfo | grep 'OpenGL core profile renderer'
OpenGL core profile renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
OpenGL core profile renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
OpenGL core profile renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
OpenGL core profile renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
OpenGL core profile renderer: NVIDIA GeForce RTX 4090/PCIe/SSE2
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))

~
❯ __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json zink-run eglinfo | grep 'OpenGL core profile renderer'
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
OpenGL core profile renderer: zink Vulkan 1.4(NVIDIA GeForce RTX 4090 (NVIDIA_PROPRIETARY))
```

https://wiki.archlinux.org/title/OpenGL#OpenGL_over_Vulkan_(Zink)

Usage with AMD gpu would need testing as I don't have one to test with. If it causes issue with AMD then something like zink-run-nvidia could be created instead.