### PR TITLE
sbctl-batch-sign: Exit the script if Limine is detected

### DIFF
--- a/usr/bin/sbctl-batch-sign
+++ b/usr/bin/sbctl-batch-sign
@@ -5,6 +5,11 @@
 # needs to be signed in EFI.
 set -e
 
+if [ -f /boot/limine.conf ]; then
+    echo "Limine detected, please do not use this script."
+    exit 0
+fi
+
 if [ "$(id -u)" -ne 0 ]; then
   echo "Error: This script must be run with root privileges."
   exit 1


### PR DESCRIPTION
Signing kernel images manually can trip Limine's checksum verification because the hash changes after signing. In fact, kernel images do not need to be signed at all since they are executed directly by Limine, bypassing EFI's chainloading and signature checks.

The only EFI binary that needs to be signed is Limine itself (handled by `limine-enroll-config`) and UEFI's backup EFI entry (`esp`/EFI/BOOT/BOOTX64.EFI) which can be signed manually instead of using this script.

Link: https://discuss.cachyos.org/t/is-there-a-solution-for-making-secure-boot-work-with-limine-snapshots/8148/5