### PR TITLE
udev: Add rule to prevent audio cracking on some hardware

### DIFF
--- a/usr/lib/modprobe.d/20-audio-pm.conf
+++ b/usr/lib/modprobe.d/20-audio-pm.conf
@@ -1,0 +1,5 @@
+# Disables power saving capabilities for snd-hda-intel when device is not
+# running on battery power. This is needed because it prevents audio cracks on
+# some hardware. If device starts working on battery power, same named udev rule
+# re-enables power saving.
+options snd_hda_intel power_save_controller=N

--- a/usr/lib/udev/rules.d/20-audio-pm.rules
+++ b/usr/lib/udev/rules.d/20-audio-pm.rules
@@ -1,0 +1,8 @@
+# Disables power saving capabilities for snd-hda-intel when device is not
+# running on battery power. This is needed because it prevents audio cracks on
+# some hardware.
+SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", TEST=="/sys/module/snd_hda_intel", \
+    RUN+="/bin/sh -c 'echo Y > /sys/module/snd_hda_intel/parameters/power_save_controller'"
+
+SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="1", TEST=="/sys/module/snd_hda_intel", \
+    RUN+="/bin/sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller'"


### PR DESCRIPTION
I received a number of reports, and decided to make a udev rule to prevent such issues with condition that we don't degrade battery life of the devices. 

Needs testing on desktop PCs.