### PR TITLE
udev: Do not disable powersaving for NVIDIA audio devices

### DIFF
--- a/usr/lib/udev/rules.d/20-audio-pm.rules
+++ b/usr/lib/udev/rules.d/20-audio-pm.rules
@@ -5,4 +5,5 @@ SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", TEST=="/sys/module/snd
     RUN+="/bin/sh -c 'echo Y > /sys/module/snd_hda_intel/parameters/power_save_controller'"
 
 SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="1", TEST=="/sys/module/snd_hda_intel", \
-    RUN+="/bin/sh -c 'echo N > /sys/module/snd_hda_intel/parameters/power_save_controller'"
+    RUN+="/bin/sh -c 'echo $(grep -w -q 0x10de /sys/module/snd_hda_intel/drivers/*/*/vendor \
+        && echo Y || echo N) > /sys/module/snd_hda_intel/parameters/power_save_controller'"


### PR DESCRIPTION
Somehow, disabling power saving for NVIDIA audio device also prevents the dGPU from going into sleep mode.

See: https://github.com/CachyOS/CachyOS-Settings/pull/147#issuecomment-2952595836