### PR TITLE
modprobe.d/nvidia: Remove modeset parameter

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,9 +16,6 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
-# nvidia_drm.modeset=1 (default 0) - Enables modesetting support for the NVIDIA
-# driver. Critical for Wayland support and proper PRIME Offload operation.
-#
 # NVreg_RegistryDwords=RMIntrLockingMode=1 (default 0) - enables experimental
 # switch for better frame-pacing this mainly improves it for high refresh rate
 # monitors with VRR or VR headsets.
@@ -37,4 +34,3 @@ options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
     NVreg_DynamicPowerManagement=0x02 \
     NVreg_RegistryDwords=RMIntrLockingMode=1
-options nvidia_drm modeset=1


### PR DESCRIPTION
All NVIDIA module packages in our repository are patched to enable modeset by default, so this is unnecessary, but can also cause issues on older driver versions such as 390.xx.

See: https://github.com/CachyOS/CachyOS-PKGBUILDS/commit/396ecc5a4a11768ff387baffe35824e473bc9b43