### PR TITLE
Reapply "tmpfiles.d: Remove interrupt frequency optimization"

### DIFF
--- a/usr/lib/tmpfiles.d/optimize-interruptfreq.conf
+++ b/usr/lib/tmpfiles.d/optimize-interruptfreq.conf
@@ -1,4 +1,0 @@
-# Increase the highest requested RTC interrupt frequency
-# https://wiki.archlinux.org/title/Professional_audio#System_configuration
-w! /sys/class/rtc/rtc0/max_user_freq - - - - 3072
-w! /proc/sys/dev/hpet/max-user-freq  - - - - 3072


### PR DESCRIPTION
I've gotten one report from a user who consistently gets hangs until deleting this file. I also doubt it's actually relevant since all mentions of it date back to 2012 and ALSA already has a snd_hrtimer module that probably makes audio processing stuff completely independent from RTC interrupt frequency.

This reverts commit a7b5af383eea9b8ef0d23beaf6f70340a46f236f.