### PR TITLE
Restore unlimited RT priority for audio

### DIFF
--- a/etc/security/limits.d/20-audio.conf
+++ b/etc/security/limits.d/20-audio.conf
@@ -1,0 +1,1 @@
+@audio - rtprio 99


### PR DESCRIPTION
This partially reverts 8181bdcb67eaffdb9cb884e4a1fd4c3aed1918fd.

The issue is that all PipeWire threads actually spawns with SCHED_FLAG_RESET_ON_FORK, which is makes ananicy rules in this case pretty useless.

On other side, realtime-privileges limits max nice level to -11, so it's breaks many of ananicy rules, so we can't recommend using it.