### PR TITLE
Update cachyos-bugreport.sh for better inxi

### DIFF
--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -74,7 +74,7 @@ uname: $(uname -a)
 ____________________________________________
 Getting Hardware Information
 
-$(inxi -F)
+$(inxi -Farz)
 ____________________________________________
 Getting Scheduler information
 


### PR DESCRIPTION
Replace 'inxi -F' with 'inxi Farz' in order to;
 - Include more machine information
 - Include boot options
 - Include more Battery information
 - Include various extra device information (audio, graphics, network, etc)
 - Include Repository information
 - MOST IMPORTANTLY - the 'z' flag is included which hides personally identifiable information such as IP