### PR TITLE
refactor(game-performance): gaming-power-profile

### DIFF
--- a/usr/bin/gaming-power-profile
+++ b/usr/bin/gaming-power-profile
@@ -11,11 +11,10 @@ if ! command -v powerprofilesctl &>/dev/null; then
 fi
 
 #######################################
-# Returns: true  - If a game is running.
-#          false - Otherwise.
+# Game detection
 #######################################
 is_game_running() {
-    # Steam game is running — very specific
+    # Steam game is running
     pgrep -f "steamapps/common" >/dev/null && return 0
 
     # Lutris (native or Flatpak)
@@ -37,22 +36,32 @@ is_game_running() {
 }
 
 #######################################
-# Poll every n seconds 
+# Main function
 #######################################
-state=""
-while true; do
-    if is_game_running; then
-        if [[ "$state" != "performance" ]]; then
-            echo "Setting power profile to performance"
-            powerprofilesctl set performance
-            state="performance"
+main() {
+    local state=""
+    while true; do
+        if is_game_running; then
+            if [[ "$state" != "performance" ]]; then
+                echo "Setting power profile to performance"
+                powerprofilesctl set performance
+                state="performance"
+            fi
+        else
+            if [[ "$state" != "balanced" ]]; then
+                echo "Setting power profile to balanced"
+                powerprofilesctl set balanced
+                state="balanced"
+            fi
         fi
-    else
-        if [[ "$state" != "balanced" ]]; then
-            echo "Setting power profile to balanced"
-            powerprofilesctl set balanced
-            state="balanced"
-        fi
-    fi
-    sleep "$POLLING_INTERVAL"
-done
+        sleep "$POLLING_INTERVAL"
+    done
+}
+
+#######################################
+# Run with systemd-inhibit
+#######################################
+exec systemd-inhibit --what=sleep \
+    --who="Gaming Power Profile" \
+    --why="Prevents the script from waking up the computer" \
+    bash -c "source \"$0\" && main"


### PR DESCRIPTION
## Proposal
This little daemon pretends to solve the problem of game-performance not being accessible from flatpak, by automatically setting power mode to "performance" when a steam game is running. Once the game is not running anymore, performance will be back to "balanced".

This PR is to game-performance what ananicy-cpp is to gamemode, kinda.

## PROS
* It can be used with flatpak.
* It doesn't require to pass "game-performance" to every game where we want to enable it.

## CONS
* Another daemon running in background.
* Not super transparent with the user.

## More info
I haven't PR the service code itself. But it's pretty straightforward. 

```
touch ~/.config/systemd/user/gaming-power-profile.service
```
And paste
```
[Unit]
Description=Gaming Power Profile
After=graphical-session.target

[Service]
ExecStart=%h/.local/bin/gaming-power-profile
Restart=on-failure
Environment=PATH=%h/.local/bin:/usr/bin:/bin

[Install]
WantedBy=default.target
```

Then enable it with
```
systemctl --user daemon-reload
systemctl --user enable --now gaming-power-profile.service
```
If this PR is accepted, please, don't forget to add the service and delete game-performance.