### PR TITLE
profile.d: Set ELECTRON_OZONE_PLATFORM_HINT to Auto

### DIFF
--- a/etc/profile.d/electron-ozone.sh
+++ b/etc/profile.d/electron-ozone.sh
@@ -1,0 +1,1 @@
+export ELECTRON_OZONE_PLATFORM_HINT=auto


### PR DESCRIPTION
The issue on RTX Cards with obsidian appears to be fixed now. 

It should be now fine to export this for all users