### PR TITLE
nvidia.conf: Enable S0ix Power Management

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -30,7 +30,15 @@
 # shows how even small delays can shift frame timing, potentially impacting
 # smooth display output.
 #
+# NVreg_EnableS0ixPowerManagement=1 (default 0) Enables S0ix for the NVIDIA GPU:
+# lets the device enter deep,
+# low-power idle states while the system uses s2idle (the S0 low-power idle path),
+# reducing battery drain—especially on laptops with recent Intel/AMD
+# platforms and Turing/Ampere/Ada GPUs
+#
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
     NVreg_DynamicPowerManagement=0x02 \
-    NVreg_RegistryDwords=RMIntrLockingMode=1
+    NVreg_RegistryDwords=RMIntrLockingMode=1 \
+    NVreg_EnableS0ixPowerManagement=1
+    


### PR DESCRIPTION
This has been enabled by Suse and Fedora since a while. Lets also enable this for newer GPUs, which should yield longer battery time, when in sleep.