### PR TITLE
nvidia.conf: Remove RMIntrLockingMode && enable AggressiveVblank

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,19 +16,6 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
-# NVreg_RegistryDwords=RMIntrLockingMode=1 (default 0) - enables experimental
-# switch for better frame-pacing this mainly improves it for high refresh rate
-# monitors with VRR or VR headsets.
-#
-# Note: This only works for PRIME configurations if your dGPU is controlling an
-# external monitor.
-#
-# For example: At 240Hz each frame is expected every 4ms. But if a 1ms
-# task—say, in the kernel or on the GSP — runs when a frame is about to be
-# displayed, it can delay the rendering. Instead of a neat sequence at T+4ms,
-# T+8ms, T+12ms, the frames might appear at T+4ms, T+9ms, T+12ms, etc. This
-# shows how even small delays can shift frame timing, potentially impacting
-# smooth display output.
 #
 # NVreg_EnableS0ixPowerManagement=1 (default 0) Enables S0ix for the NVIDIA GPU:
 # lets the device enter deep,
@@ -36,9 +23,12 @@
 # reducing battery drain—especially on laptops with recent Intel/AMD
 # platforms and Turing/Ampere/Ada GPUs
 #
+# NVreg_RegistryDwords=RmEnableAggressiveVblank=1
+# Reduce time spent in interrupt top half for low latency display interrupts
+# by deferring the work later
+
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
     NVreg_DynamicPowerManagement=0x02 \
-    NVreg_RegistryDwords=RMIntrLockingMode=1 \
-    NVreg_EnableS0ixPowerManagement=1
-    
+    NVreg_EnableS0ixPowerManagement=1 \
+    NVreg_RegistryDwords=RmEnableAggressiveVblank=1


### PR DESCRIPTION
This is for the 580 series, when getting merged.

RMIntrLockingMode has been enabled OOB.

The new RmEnableAggressiveVblank=1 is a experimental flag:

> Implemented another feature that can reduce time spent in the interrupt top half for low latency display interrupts by deferring the work until later. This feature is experimental and disabled by default. This feature can be enabled by loading nvidia.ko with the `NVreg_RegistryDwords=RmEnableAggressiveVblank=1` kernel module parameter.