### PR TITLE
udev: Only apply hdparm udev rule on ATA devices

### DIFF
--- a/usr/lib/udev/rules.d/69-hdparm.rules
+++ b/usr/lib/udev/rules.d/69-hdparm.rules
@@ -1,2 +1,2 @@
 ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1", \
-    RUN+="/usr/bin/hdparm -B 254 -S 0 /dev/%k"
+    ATTRS{id/bus}=="ata", RUN+="/usr/bin/hdparm -B 254 -S 0 /dev/%k"


### PR DESCRIPTION
fixes #163