### PR TITLE
nvidia.conf: enable RmEnableAggressiveVblank

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,6 +16,12 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
+# NVreg_RegistryDwords=RmEnableAggressiveVblank=1
+# Reduce time spent in interrupt top half for low latency display interrupts
+# by deferring the work later
+#
+
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
-    NVreg_DynamicPowerManagement=0x02
+    NVreg_DynamicPowerManagement=0x02 \
+    NVreg_RegistryDwords=RmEnableAggressiveVblank=1


### PR DESCRIPTION
The new RmEnableAggressiveVblank=1 is a experimental flag:

> Implemented another feature that can reduce time spent in the interrupt top half for low latency display interrupts by deferring the work until later. This feature is experimental and disabled by default. This feature can be enabled by loading nvidia.ko with the `NVreg_RegistryDwords=RmEnableAggressiveVblank=1` kernel module parameter.