### PR TITLE
udev: Setup audio power saving on system boot

### DIFF
--- a/usr/lib/modprobe.d/20-audio-pm.conf
+++ b/usr/lib/modprobe.d/20-audio-pm.conf
@@ -1,5 +1,0 @@
-# Disables power saving capabilities for snd-hda-intel when device is not
-# running on battery power. This is needed because it prevents audio cracks on
-# some hardware. If device starts working on battery power, same named udev rule
-# re-enables power saving.
-options snd_hda_intel power_save=0

--- a/usr/lib/udev/rules.d/20-audio-pm.rules
+++ b/usr/lib/udev/rules.d/20-audio-pm.rules
@@ -1,11 +1,17 @@
 # Disables power saving capabilities for snd-hda-intel when device is not
 # running on battery power. This is needed because it prevents audio cracks on
 # some hardware.
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card*", DRIVERS=="snd_hda_intel", TEST!="/run/udev/snd-hda-intel-powersave", \
+    RUN+="/usr/bin/bash -c 'touch /run/udev/snd-hda-intel-powersave; \
+        [[ $$(cat /sys/class/power_supply/BAT0/status 2>/dev/null) != \"Discharging\" ]] && \
+        echo $$(cat /sys/module/snd_hda_intel/parameters/power_save) > /run/udev/snd-hda-intel-powersave && \
+        echo 0 > /sys/module/snd_hda_intel/parameters/power_save'"
+
 SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", TEST=="/sys/module/snd_hda_intel", \
-    RUN+="/bin/sh -c 'echo $$(cat /run/udev/snd-hda-intel-powersave 2>/dev/null || \
+    RUN+="/usr/bin/bash -c 'echo $$(cat /run/udev/snd-hda-intel-powersave 2>/dev/null || \
         echo 10) > /sys/module/snd_hda_intel/parameters/power_save'"
 
 SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="1", TEST=="/sys/module/snd_hda_intel", \
-    RUN+="/bin/sh -c '[[ $$(cat /sys/module/snd_hda_intel/parameters/power_save) != 0 ]] && \
+    RUN+="/usr/bin/bash -c '[[ $$(cat /sys/module/snd_hda_intel/parameters/power_save) != 0 ]] && \
         echo $$(cat /sys/module/snd_hda_intel/parameters/power_save) > /run/udev/snd-hda-intel-powersave; \
         echo 0 > /sys/module/snd_hda_intel/parameters/power_save'"


### PR DESCRIPTION
This also allows us to get rid of the unnecessary modprobe config, which is not flexible at all.

Fixes: https://github.com/CachyOS/CachyOS-Settings/issues/171