### PR TITLE
Update 99-cachyos-settings.conf

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -25,10 +25,6 @@ vm.dirty_background_bytes = 67108864
 # tunable expresses the interval between those wakeups, in 100'ths of a second (Default is 500).
 vm.dirty_writeback_centisecs = 1500
 
-# This action will speed up your boot and shutdown, because one less module is loaded. Additionally disabling watchdog timers increases performance and lowers power consumption
-# Disable NMI watchdog
-kernel.nmi_watchdog = 0
-
 # Enable the sysctl setting kernel.unprivileged_userns_clone to allow normal users to run unprivileged containers.
 kernel.unprivileged_userns_clone = 1
 


### PR DESCRIPTION
**Remove `kernel.nmi_watchdog = 0` configuration parameter from `99-cachyos-settings.conf`**

The NMI watchdog is already disabled via the CachyOS-settings modprobe blacklist configuration (`/usr/lib/modprobe.d/blacklist.conf`), which blacklists the relevant watchdog modules:

```
# Blacklist the Intel TCO Watchdog/Timer module
blacklist iTCO_wdt

# Blacklist the AMD SP5100 TCO Watchdog/Timer module (Required for Ryzen cpus)
blacklist sp5100_tco
```

The existing `kernel.nmi_watchdog = 0` sysctl parameter is therefore redundant and causes errors during system updates when pacman applies sysctl settings:

```
( 7/14) Applying kernel sysctl settings...
Couldn't write '0' to 'kernel/nmi_watchdog', ignoring: No such file or directory
```

Since the watchdog functionality is already disabled at the module level, this sysctl parameter should be removed to eliminate unnecessary error messages during package manager operations.
