### PR TITLE
sysctl: Remove disabling kexec load setting

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -38,9 +38,6 @@ kernel.printk = 3 3 3 3
 # Restricting access to kernel pointers in the proc filesystem
 kernel.kptr_restrict = 2
 
-# Disable Kexec, which allows replacing the current running kernel.
-kernel.kexec_load_disabled = 1
-
 # Increase netdev receive queue
 # May help prevent losing packets
 net.core.netdev_max_backlog = 4096


### PR DESCRIPTION
This affects cachyos-kdump-tools operation, so we should keep it enabled to avoid conflicts. Also I don’t think this has any big security concern as hardering is not main priority within these settings.

Closes: https://github.com/CachyOS/cachyos-kdump-tools/issues/2 https://github.com/CachyOS/CachyOS-Settings/issues/178