### PR TITLE
Update network performance 99-cachyos-settings.conf

### DIFF
--- a/usr/lib/sysctl.d/99-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/99-cachyos-settings.conf
@@ -98,7 +98,8 @@ net.ipv4.tcp_mtu_probing = 1
 net.ipv4.tcp_slow_start_after_idle = 0
 
 # --- 9. Aggressive Keepalives (NAT Persistence) ---
-# Reduces the time before keepalive packets are sent (Default: 2 hours -> 60s).
+# Reduces the time before keepalive packets are sent (Default: 120s on Arch Linux -> 60s).
+# https://gitlab.archlinux.org/archlinux/rfcs/-/merge_requests/51
 # Benefit: Prevents aggressive Carrier-Grade NATs (CGNAT) or Mobile Networks from closing idle connections.
 # Use Case: Keeps RustDesk, SSH, and Database connections alive on mobile data.
 net.ipv4.tcp_keepalive_time = 60


### PR DESCRIPTION
I have been testing these for about a week. I had some inaccurate values, but it seems promising now.

Rustdesk can achieve usable gaming at 80-100 FPS on a LAN connection. Sunshine + Moonlight also works perfectly, even at a 150 Mbps bitrate with H.265, with no drops or lags.

Results over WAN (Tailscale) are pretty similar when direct P2P is achieved and both sides have a decent network.

I believe my personal tweaks would be useful for CachyOS.