### PR TITLE
feat: Configure Qdisc and enable BBR for TCP

### DIFF
--- a/usr/lib/sysctl.d/70-cachyos-settings.conf
+++ b/usr/lib/sysctl.d/70-cachyos-settings.conf
@@ -42,8 +42,8 @@ kernel.kptr_restrict = 2
 # May help prevent losing packets
 net.core.netdev_max_backlog = 4096
 
-# Set Qdisc to fq (Fair Queue)
-net.core.default_qdisc = fq
+# Set Qdisc (Fair Queue)
+net.core.default_qdisc = fq_codel
 # Enable BBR as TCP Congestion Control
 net.ipv4.tcp_congestion_control = bbr
 


### PR DESCRIPTION
Added settings for Qdisc and TCP congestion control. 
Without both settings, BBR3 won't be used even with the kernel patch applied.

Reports here:
https://discuss.cachyos.org/t/bbr3-not-working/12908