### PR TITLE
Remove NVreg_DynamicPowerManagement option

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -12,10 +12,6 @@
 # /etc/modprobe.d/nvidia.conf, if you want to return the default value. Note:
 # It is possible to use more memory (?)
 #
-# NVreg_DynamicPowerManagement=0x02 - Enables the use of dynamic power
-# management for Turing generation mobile cards, allowing the dGPU to be
-# powered down during idle time.
-#
 # NVreg_RegistryDwords=RmEnableAggressiveVblank=1
 # Reduce time spent in interrupt top half for low latency display interrupts
 # by deferring the work until later
@@ -23,5 +19,4 @@
 
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
-    NVreg_DynamicPowerManagement=0x02 \
     NVreg_RegistryDwords=RmEnableAggressiveVblank=1


### PR DESCRIPTION
See: https://download.nvidia.com/XFree86/Linux-x86_64/465.19.01/README/dynamicpowermanagement.html

```
Option "NVreg_DynamicPowerManagement=0x03"
This is the default setting.

For Ampere or later notebooks with supported configurations, this value translates to fine-grained power control. For pre-Ampere notebooks, this value disables runtime D3 power management features.
```

I believe it does uses `0x02` by default on pre-Ampere devices.