### PR TITLE
Add mousewheel scroll speed quirk for Logitech G502 in libinput

### DIFF
--- a/etc/libinput/g502-wheelscroll-fix.quirks
+++ b/etc/libinput/g502-wheelscroll-fix.quirks
@@ -1,0 +1,3 @@
+[Logitech G502]
+MatchName=*Logitech G502*
+AttrEventCode=-REL_WHEEL_HI_RES;-REL_WHEEL_HI_RES;


### PR DESCRIPTION
This is a temporary fix for a problem related to the "hid-logitech-hidpp" driver, which causes the mousewheel to send too many events in a short period causing the wheel to be moved too fast.

This affects CS2, Minecraft and Hytale in my testing. Both in Hytale and Minecraft, when using the mousewheel you should be able to scroll slot by slot, not skip 10 of them. I didn't test CS2 yet, but I had problems with not being able to switch between weapons correctly because it was scrolling too fast.

This is a temporary fix - it basically ignores the high-resolution inputs of the mousewheel and makes scrolling in game hotbars/inventories more pleasant again.

In my testing, it does not interfere with the scrolling speed in any other app.