### PR TITLE
Fix polkit agent permissions for COSMIC desktop environment

### DIFF
--- a/usr/lib/tmpfiles.d/polkit-agent.conf
+++ b/usr/lib/tmpfiles.d/polkit-agent.conf
@@ -1,0 +1,5 @@
+# Fix polkit agent permissions for COSMIC desktop environment
+# Sets the setuid bit on polkit-agent-helper-1 to allow password input in auth dialogs
+# Creates symlink for cosmic-osd compatibility
+f /usr/lib/polkit-1/polkit-agent-helper-1 4755 root root -
+L+ /usr/libexec/polkit-agent-helper-1 - - - - /usr/lib/polkit-1/polkit-agent-helper-1


### PR DESCRIPTION
This commit adds a tmpfiles.d configuration to persistently set the setuid bit on polkit-agent-helper-1 and create a symlink for cosmic-osd compatibility.

The issue:
- polkit-agent-helper-1 requires setuid root permissions to allow password input in authentication dialogs
- Arch Linux polkit package (v127-3, commit f2e63152) removed the setuid bit, assuming socket activation would replace it
- COSMIC desktop environment still requires the setuid helper for authentication dialogs to function properly
- Without setuid, password input in auth dialogs is rejected immediately

The fix:
- Uses systemd tmpfiles.d to set permissions (4755) on boot/install
- Creates symlink at /usr/libexec/polkit-agent-helper-1 for cosmic-osd compatibility
- Persists across package updates (unlike manual chmod)

References:
- CachyOS Forum #20587: COSMIC Auth failing: polkit-agent-helper-1 missing SUID bit on CachyOS
- CachyOS Forum #20592: Polkit Authentication Issue with COSMIC Desktop Environment
- Arch Linux polkit commit f2e63152: Remove suid and statically activate agent helper
- Debian Bug #1125141: polkitd: polkit-agent-helper-1 missing setuid bit