### PR TITLE
Revert "nvidia.conf: Remove S01xPM due suspend issues"

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,7 +16,13 @@
 # Reduce time spent in interrupt top half for low latency display interrupts
 # by deferring the work until later
 #
-
+# NVreg_EnableS0ixPowerManagement=1 (default 0) Enables S0ix for the NVIDIA GPU:
+# lets the device enter deep,
+# low-power idle states while the system uses s2idle (the S0 low-power idle path),
+# reducing battery drain—especially on laptops with recent Intel/AMD
+# platforms and Turing/Ampere/Ada GPUs
+#
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
-    NVreg_RegistryDwords=RmEnableAggressiveVblank=1
+    NVreg_RegistryDwords=RmEnableAggressiveVblank=1 \
+    NVreg_EnableS0ixPowerManagement=1


### PR DESCRIPTION
This reverts commit a559ecccf0844dc1f4a81bdedf3b5e15899304b6.

Although this was removed because of suspend issues, the removal of this caused even more suspend issues to be reported [1]. The presence of this option seems to be more helpful rather than not so add it back.

[1] https://github.com/CachyOS/linux-cachyos/issues/493