### PR TITLE
udev: sata: Check if LPM is supported

### DIFF
--- a/usr/lib/udev/rules.d/50-sata.rules
+++ b/usr/lib/udev/rules.d/50-sata.rules
@@ -1,4 +1,5 @@
 # SATA Active Link Power Management
 ACTION=="add", SUBSYSTEM=="scsi_host", KERNEL=="host*", \
+    ATTR{link_power_management_supported}=="1", \
     ATTR{link_power_management_policy}=="*", \
     ATTR{link_power_management_policy}="max_performance"


### PR DESCRIPTION
Since 6.18.8, link_power_management_supported attribute correctly advertises LPM support. Hence, we should check this to not run the udev on unsupported devices like

(udev-worker)[506]: host0: /usr/lib/udev/rules.d/50-sata.rules:2 ATTR{link_power_management_policy
}="max_performance": Failed to write "max_performance" to sysfs attribute "link_power_management_policy", ignoring: Operation not supported
(udev-worker)[501]: host3: /usr/lib/udev/rules.d/50-sata.rules:2 ATTR{link_power_management_policy
}="max_performance": Failed to write "max_performance" to sysfs attribute "link_power_management_policy", ignoring: Operation not supported
(udev-worker)[531]: host5: /usr/lib/udev/rules.d/50-sata.rules:2 ATTR{link_power_management_policy
}="max_performance": Failed to write "max_performance" to sysfs attribute "link_power_management_policy", ignoring: Operation not supported
(udev-worker)[510]: host1: /usr/lib/udev/rules.d/50-sata.rules:2 ATTR{link_power_management_policy
}="max_performance": Failed to write "max_performance" to sysfs attribute "link_power_management_policy", ignoring: Operation not supported
(udev-worker)[546]: host4: /usr/lib/udev/rules.d/50-sata.rules:2 ATTR{link_power_management_policy
}="max_performance": Failed to write "max_performance" to sysfs attribute "link_power_management_policy", ignoring: Operation not supported

Keep the original `link_power_management_policy` attribute for fallback on older kernels.