### PR TITLE
udev: Skip audio power_save override for AMD HDA controllers (#204)

### DIFF
--- a/usr/lib/udev/rules.d/20-audio-pm.rules
+++ b/usr/lib/udev/rules.d/20-audio-pm.rules
@@ -1,17 +1,19 @@
 # Disables power saving capabilities for snd-hda-intel when device is not
 # running on battery power. This is needed because it prevents audio cracks on
-# some hardware.
-ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card*", DRIVERS=="snd_hda_intel", TEST!="/run/udev/snd-hda-intel-powersave", \
+# some Intel hardware. AMD HDA controllers are excluded because on platforms
+# like Strix/Krackan, the audio controller shares a PCI bus with the GPU and
+# keeping it awake causes electrical interference/buzzing during GPU activity.
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="card*", DRIVERS=="snd_hda_intel", ATTRS{vendor}=="0x8086", TEST!="/run/udev/snd-hda-intel-powersave", \
     RUN+="/usr/bin/bash -c 'touch /run/udev/snd-hda-intel-powersave; \
         [[ $$(cat /sys/class/power_supply/BAT0/status 2>/dev/null) != \"Discharging\" ]] && \
         echo $$(cat /sys/module/snd_hda_intel/parameters/power_save) > /run/udev/snd-hda-intel-powersave && \
         echo 0 > /sys/module/snd_hda_intel/parameters/power_save'"
 
-SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", TEST=="/sys/module/snd_hda_intel", \
+SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="0", TEST=="/sys/module/snd_hda_intel", TEST=="/run/udev/snd-hda-intel-powersave", \
     RUN+="/usr/bin/bash -c 'echo $$(cat /run/udev/snd-hda-intel-powersave 2>/dev/null || \
         echo 10) > /sys/module/snd_hda_intel/parameters/power_save'"
 
-SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="1", TEST=="/sys/module/snd_hda_intel", \
+SUBSYSTEM=="power_supply", ENV{POWER_SUPPLY_ONLINE}=="1", TEST=="/sys/module/snd_hda_intel", TEST=="/run/udev/snd-hda-intel-powersave", \
     RUN+="/usr/bin/bash -c '[[ $$(cat /sys/module/snd_hda_intel/parameters/power_save) != 0 ]] && \
         echo $$(cat /sys/module/snd_hda_intel/parameters/power_save) > /run/udev/snd-hda-intel-powersave; \
         echo 0 > /sys/module/snd_hda_intel/parameters/power_save'"


### PR DESCRIPTION
On AMD Strix/Krackan laptops, the audio controller shares a PCI bus with the GPU. Forcing power_save=0 keeps the codec in D0 state, causing audible electrical interference/buzzing during GPU and NVMe activity.

Restrict the power_save=0 override to Intel HDA controllers (vendor 0x8086), which are the hardware affected by the audio popping that this rule was designed to prevent. AMD HDA controllers now keep their default power_save behavior, allowing them to suspend when idle and eliminating the EMI noise.

Also guard the AC/battery power_supply rules on the flag file existence so they only fire on systems where the boot rule actually applied.

Closes #204