### PR TITLE
regdomain: Automatically set the wireless regularity domain

### DIFF
--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+# SPDX-FileCopyrightText: 2009-2014 Red Hat, Inc.
+# SPDX-FileCopyrightText: 2025 Velocity Limitless, LLC.
+
+# See https://gitlab.com/VelocityLimitless/Projects/iw-setregdomain
+
+# Copyright 2009-2014 Red Hat, Inc.  All rights reserved.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+REGDOMAIN=/etc/iw-regdomain
+LOCALTIME=/etc/localtime
+
+LOGGER="/usr/bin/logger -t iw-set-regdomain"
+
+getcountry() {
+	while read c a z r
+	do
+		if [ "$z" = "$ZONE" ]
+		then
+			echo $c
+			break
+		fi
+	done < /usr/share/zoneinfo/zone.tab
+}
+
+if [ -f $REGDOMAIN ]
+then
+	# This should set COUNTRY
+	. $REGDOMAIN
+	if [ -n "$COUNTRY" ]
+	then
+		/usr/bin/iw reg set $COUNTRY
+		exit
+	fi
+fi
+
+if [ -f "$LOCALTIME" ]
+then
+	ZONE=$(readlink -f $LOCALTIME)
+	ZONE=${ZONE#/usr/share/zoneinfo/}
+else
+	$LOGGER -s "Timezone information not found. Unable to set wireless regulatory domain."
+	exit 1
+fi
+
+if [ -z "$ZONE" -o "$ZONE" = "$LOCALTIME" ]
+then
+	$LOGGER -s "Could not determine timezone. Unable to set wireless regulatory domain."
+	exit 1
+fi
+
+COUNTRY=$(getcountry)
+
+if [ -z "$COUNTRY" ]
+then
+	case "$ZONE" in
+        UTC|UCT|Universal|Zulu|GMT|Etc/UTC|Etc/UCT|Etc/Universal|Etc/Zulu|Etc/GMT)
+            $LOGGER "Timezone is $ZONE, with no associated country. Not setting wireless regulatory domain."
+            exit 0
+            ;;
+    esac
+
+    $LOGGER -s "Could not determine country for $ZONE. Unable to set wireless regulatory domain."
+    exit 1
+fi
+
+$LOGGER "Setting regulatory domain to $COUNTRY based on timezone ($ZONE)."
+/usr/bin/iw reg set $COUNTRY

--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -38,13 +38,12 @@ getcountry() {
 	done < /usr/share/zoneinfo/zone.tab
 }
 
-if [ -f $REGDOMAIN ]
+if [ -f "$REGDOMAIN" ]
 then
-	# This should set COUNTRY
-	. $REGDOMAIN
+	COUNTRY=$(sed -n 's/^COUNTRY=//p' "$REGDOMAIN" | head -1)
 	if [ -n "$COUNTRY" ]
 	then
-		/usr/bin/iw reg set $COUNTRY
+		/usr/bin/iw reg set "$COUNTRY"
 		exit
 	fi
 fi

--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -23,7 +23,6 @@
 #
 
 REGDOMAIN=/etc/iw-regdomain
-LOCALTIME=/etc/localtime
 
 LOGGER="/usr/bin/logger -t iw-set-regdomain"
 
@@ -48,16 +47,9 @@ then
 	fi
 fi
 
-if [ -f "$LOCALTIME" ]
-then
-	ZONE=$(readlink -f "$LOCALTIME")
-	ZONE=${ZONE#/usr/share/zoneinfo/}
-else
-	$LOGGER -s "Timezone information not found. Unable to set wireless regulatory domain."
-	exit 1
-fi
+ZONE=$(timedatectl show -P Timezone 2>/dev/null)
 
-if [ -z "$ZONE" -o "$ZONE" = "$LOCALTIME" ]
+if [ -z "$ZONE" ]
 then
 	$LOGGER -s "Could not determine timezone. Unable to set wireless regulatory domain."
 	exit 1

--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -32,7 +32,7 @@ getcountry() {
 	do
 		if [ "$z" = "$ZONE" ]
 		then
-			echo $c
+			echo "$c"
 			break
 		fi
 	done < /usr/share/zoneinfo/zone.tab
@@ -50,7 +50,7 @@ fi
 
 if [ -f "$LOCALTIME" ]
 then
-	ZONE=$(readlink -f $LOCALTIME)
+	ZONE=$(readlink -f "$LOCALTIME")
 	ZONE=${ZONE#/usr/share/zoneinfo/}
 else
 	$LOGGER -s "Timezone information not found. Unable to set wireless regulatory domain."
@@ -79,4 +79,4 @@ then
 fi
 
 $LOGGER "Setting regulatory domain to $COUNTRY based on timezone ($ZONE)."
-/usr/bin/iw reg set $COUNTRY
+/usr/bin/iw reg set "$COUNTRY"

--- a/usr/lib/systemd/system/cachyos-iw-set-regdomain.path
+++ b/usr/lib/systemd/system/cachyos-iw-set-regdomain.path
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+
+[Unit]
+Description=Monitor Timezone Changes to Set Wireless Regulatory Domain
+
+[Path]
+PathChanged=/etc/localtime
+Unit=cachyos-iw-set-regdomain.service
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/cachyos-iw-set-regdomain.service
+++ b/usr/lib/systemd/system/cachyos-iw-set-regdomain.service
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+
+[Unit]
+Description=Set Wireless Regulatory Domain on Timezone Change
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/iw-set-regdomain

--- a/usr/lib/systemd/system/cachyos-iw-set-regdomain.service
+++ b/usr/lib/systemd/system/cachyos-iw-set-regdomain.service
@@ -3,6 +3,7 @@
 
 [Unit]
 Description=Set Wireless Regulatory Domain on Timezone Change
+After=local-fs.target
 
 [Service]
 Type=oneshot

--- a/usr/lib/udev/rules.d/85-iw-regulatory.rules
+++ b/usr/lib/udev/rules.d/85-iw-regulatory.rules
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: ISC
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+# SPDX-FileCopyrightText: 2009-2014 Red Hat, Inc.
+# SPDX-FileCopyrightText: 2025 Velocity Limitless, LLC.
+
+# Set wireless regulatory domain at device creation
+# For more information see https://gitlab.com/VelocityLimitless/Projects/iw-setregdomain
+
+SUBSYSTEM=="ieee80211", ACTION=="add", RUN+="/usr/lib/iw-set-regdomain"

--- a/usr/lib/udev/rules.d/85-iw-regulatory.rules
+++ b/usr/lib/udev/rules.d/85-iw-regulatory.rules
@@ -6,4 +6,4 @@
 # Set wireless regulatory domain at device creation
 # For more information see https://gitlab.com/VelocityLimitless/Projects/iw-setregdomain
 
-SUBSYSTEM=="ieee80211", ACTION=="add", RUN+="/usr/lib/iw-set-regdomain"
+SUBSYSTEM=="ieee80211", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}+="cachyos-iw-set-regdomain.service"


### PR DESCRIPTION
Mostly taken from https://invent.kde.org/kde-linux/kde-linux/-/commit/8cc8ad3989d338eedae01d037728b358f0ebc69a