### PR TITLE
modprobe: Hijack loading r8169 if r8125 is found

### DIFF
--- a/usr/lib/modprobe.d/r8125-loader.conf
+++ b/usr/lib/modprobe.d/r8125-loader.conf
@@ -1,0 +1,2 @@
+# modprobe r8125 is a no-op if it is already loaded
+install r8169 /usr/bin/modprobe r8125 || /usr/bin/modprobe --ignore-install r8169


### PR DESCRIPTION
For the RTL8125, RTL8162, and Realtek E3000 ethernet cards, both of these drivers serve the same purpose. However, some users have experienced dissatisfaction with the r8169 driver with these cards (slower speeds, etc). In almost all cases, r8125 solves these issues.

Since 6.19.0, we started shipping r8125 as an in-tree module and stopped r8169 from loading for these devices. However, this driver causes issues with other hardware so we decided to make it opt-in via [1]. The next problem was how to get r8125 to load without it fighting for control with r8169.

Shipping a blacklist config could work, but this causes all sorts of issues down the line as well, namely:
1. Kernels without the r8125 will have no internet connection because r8169 is blacklisted, especially tough for Arch kernel compatibility
2. Shipping a blacklist file for each <kernel>-r8125 is wasted disk space.

Hijacking r8169 is also another solution. If the r8125 module is found, it will load that driver instead of r8169, else it will load r8169 as usual.

[1] https://github.com/CachyOS/linux-cachyos/commit/94aaba512f0e654e94cbcb7cd30230dd691d039b