### PR TITLE
modprobe.d: Remove use of amdgpu on GCN 1.0/2.0

### DIFF
--- a/usr/lib/modprobe.d/amdgpu.conf
+++ b/usr/lib/modprobe.d/amdgpu.conf
@@ -1,4 +1,0 @@
-# Force using of the amdgpu driver for Southern Islands (GCN 1.0+) and Sea
-# Islands (GCN 2.x) generations.
-options amdgpu si_support=1 cik_support=1
-options radeon si_support=0 cik_support=0


### PR DESCRIPTION
This was enabled by default in 6.19. Although this may still be needed on LTS kernels, it makes sense to deliver them without amdgpu on these generations as a fallback option in case of issues with 6.19.