### PR TITLE
Refactor I/O udev rules for stability and robustness

### DIFF
--- a/usr/lib/udev/rules.d/60-ioschedulers.rules
+++ b/usr/lib/udev/rules.d/60-ioschedulers.rules
@@ -4,7 +4,7 @@ ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
 
 # SSD
 ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
-    ATTR{queue/scheduler}="bfq"
+    ATTR{queue/scheduler}="mq-deadline"
 
 # NVMe SSD
 ACTION=="add|change", KERNEL=="nvme[0-9]*", ENV{DEVTYPE}=="disk", \

--- a/usr/lib/udev/rules.d/60-ioschedulers.rules
+++ b/usr/lib/udev/rules.d/60-ioschedulers.rules
@@ -1,11 +1,14 @@
 # HDD
-ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
+    KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
     ATTR{queue/scheduler}="bfq"
 
 # SSD
-ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
+    KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
     ATTR{queue/scheduler}="mq-deadline"
 
 # NVMe SSD
-ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
+    KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
     ATTR{queue/scheduler}="none"

--- a/usr/lib/udev/rules.d/60-ioschedulers.rules
+++ b/usr/lib/udev/rules.d/60-ioschedulers.rules
@@ -1,8 +1,11 @@
 # HDD
-ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
+    ATTR{queue/scheduler}="bfq"
 
 # SSD
-ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
+    ATTR{queue/scheduler}="bfq"
 
 # NVMe SSD
-ACTION=="add|change", KERNEL=="nvme[0-9]*", ENV{DEVTYPE}=="disk", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="nvme[0-9]*", ENV{DEVTYPE}=="disk", \
+    ATTR{queue/scheduler}="none"

--- a/usr/lib/udev/rules.d/60-ioschedulers.rules
+++ b/usr/lib/udev/rules.d/60-ioschedulers.rules
@@ -1,14 +1,8 @@
 # HDD
-ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
-    KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", \
-    ATTR{queue/scheduler}="bfq"
+ACTION=="add|change", KERNEL=="sd[a-z]*", ATTR{queue/rotational}=="1", ATTR{queue/scheduler}="bfq"
 
 # SSD
-ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
-    KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", \
-    ATTR{queue/scheduler}="mq-deadline"
+ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="bfq"
 
 # NVMe SSD
-ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="zram*", \
-    KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
-    ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="nvme[0-9]*", ENV{DEVTYPE}=="disk", ATTR{queue/scheduler}="none"


### PR DESCRIPTION
Suggestion:
I know this is currently the arch way to set the udev rules for the I/O scheduler. Maybe they could be optimized for greater stability and robustness. Currently, they rely solely on kernel naming conventions, which is acceptable but can be somewhat imprecise.

I propose adding explicit subsystem filtering and excluding virtual devices such as loopbacks or zram. This will keep the logic clearer and make the rules more future-proof should kernel patterns be expanded in the future.

Note: Although `KERNEL!="loop*"` and `KERNEL!="zram*"` are technically redundant given the current specific kernel matches (`sd[a-z]*`, `mmcblk*`, `nvme*`), they are retained for clarity and robustness. This prevents accidental application to virtual devices and in case if the positive match patterns should be expanded in the future.