### PR TITLE
tmpfiles: use type 'e' for coredump cleanup to avoid duplicate warning

### DIFF
--- a/usr/lib/tmpfiles.d/coredump.conf
+++ b/usr/lib/tmpfiles.d/coredump.conf
@@ -1,2 +1,2 @@
-# Clear all coredumps that were created more than 3 days ago
-d /var/lib/systemd/coredump 0755 root root 3d
+# Override coredump cleanup age from 2w (systemd default) to 3d
+e /var/lib/systemd/coredump - - - 3d


### PR DESCRIPTION
## Summary
- `coredump.conf` and systemd's `systemd.conf` both declare a `d` entry for `/var/lib/systemd/coredump`, causing a warning on every boot:
  `Duplicate line for path "/var/lib/systemd/coredump", ignoring.`
- Switch from `d` (create directory) to `e` (clean existing directory) since `systemd.conf` already handles directory creation
- The `e` type only overrides the cleanup age without redeclaring the path

Fixes #110