### PR TITLE
nvidia: Remove EnableAggressiveVblank=1 due VR issues

### DIFF
--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -16,9 +16,6 @@
 # management for Turing generation mobile cards, allowing the dGPU to be
 # powered down during idle time.
 #
-# NVreg_RegistryDwords=RmEnableAggressiveVblank=1
-# Reduce time spent in interrupt top half for low latency display interrupts
-# by deferring the work until later
 #
 # NVreg_EnableS0ixPowerManagement=1 (default 0) Enables S0ix for the NVIDIA GPU:
 # lets the device enter deep,
@@ -28,6 +25,5 @@
 #
 options nvidia NVreg_UsePageAttributeTable=1 \
     NVreg_InitializeSystemMemoryAllocations=0 \
-    NVreg_RegistryDwords=RmEnableAggressiveVblank=1 \
     NVreg_DynamicPowerManagement=0x02 \
     NVreg_EnableS0ixPowerManagement=1


### PR DESCRIPTION
An user has reported that in VR the Performance gets really bad due this. Remove it, till NVIDIA considers enabling it as default and these problems are fixed.

Links:
https://forums.developer.nvidia.com/t/590-release-feedback-discussion/353310/467

Internal id:
 5778455 SteamVR performance is horrible with lot of frames are either dropped or extremely late with driver 590.48.01 Update: Team is currently trying to duplicate issue in labs.
 
 https://forums.developer.nvidia.com/t/590-release-feedback-discussion/353310/185?u=silly