### PR TITLE
ioschedulers: switch NVMe scheduler from none to kyber

### DIFF
--- a/usr/lib/udev/rules.d/60-ioschedulers.rules
+++ b/usr/lib/udev/rules.d/60-ioschedulers.rules
@@ -8,4 +8,4 @@ ACTION=="add|change", KERNEL=="sd[a-z]*|mmcblk[0-9]*", ATTR{queue/rotational}=="
 
 # NVMe SSD
 ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/rotational}=="0", \
-    ATTR{queue/scheduler}="none"
+    ATTR{queue/scheduler}="kyber"


### PR DESCRIPTION
While none provides marginally better throughput on empty or lightly used NVMe drives, performance degrades under mixed workloads as the drive fills up. Kyber is designed for fast multi-queue devices and enforces latency targets by throttling queue depth under congestion, providing more consistent read/write latency on drives that are 50%+ filled, which reflects real-world desktop usage.