### PR TITLE
Blacklist Intel Overclocking Watchdog Driver

### DIFF
--- a/usr/lib/modprobe.d/blacklist.conf
+++ b/usr/lib/modprobe.d/blacklist.conf
@@ -1,5 +1,8 @@
 # Blacklist the Intel TCO Watchdog/Timer module
 blacklist iTCO_wdt
 
+# Blacklist Intel Overclocking Watchdog Driver
+blacklist intel_oc_wdt
+
 # Blacklist the AMD SP5100 TCO Watchdog/Timer module (Required for Ryzen cpus)
 blacklist sp5100_tco


### PR DESCRIPTION
Intel OC Watchdog driver for Linux is a watchdog driver and matches to the Intel INT3F0D and INTC1099 device IDs.
These IDs match to the Intel Watchdog Timer "WDT" driver on Microsoft Windows.

Proably should be disabled in CachyOS as other hardware watchdog timers are also disabled.