### PR TITLE
net: disable WiFi power save by default

### DIFF
--- a/usr/lib/NetworkManager/conf.d/wifi-powersave.conf
+++ b/usr/lib/NetworkManager/conf.d/wifi-powersave.conf
@@ -1,0 +1,2 @@
+[connection]
+wifi.powersave = 2


### PR DESCRIPTION
Adds a NetworkManager configuration to disable WiFi power saving by default.
                                                                                                        
Power save mode introduces latency spikes and inconsistent throughput,
which conflicts with CachyOS's focus on responsiveness. This is a common                              
tweak recommended for gaming and low-latency workloads.                                             
                                                                                                        
The setting uses NetworkManager's native configuration instead of iw                                  
commands, so it works regardless of the interface name (wlan0, wlp3s0, etc.)                          
and is applied automatically on reconnect.                                                            
                                                                                                        
wifi.powersave = 2 → disabled                                                                         
wifi.powersave = 3 → enabled (NM default)