### PR TITLE
nvidia.conf: Remove deprecated NVreg_UsePageAttributeTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sysctl parameters modify kernel behavior at runtime for system-wide performance 
 Modprobe configurations control module loading and behavior for hardware-specific optimizations.
 * **AMD GPU Driver Enforcement**: Enables `amdgpu` SI/CIK support and disables the corresponding `radeon` support for GCN 1.0+ and 2.x GPUs.
 * **Watchdog Module Blacklist**: Prevents loading of Intel TCO and AMD SP5100 watchdog timers.
-* **NVIDIA Driver Optimizations**: Applies `NVreg_UsePageAttributeTable=1` (PAT for CPU performance), `NVreg_InitializeSystemMemoryAllocations=0` (disables memory clearing for GPU allocations), `NVreg_DynamicPowerManagement=0x02` (mobile GPU power saving), and `NVreg_EnableS0ixPowerManagement=1` (S0ix idle power saving on supported laptops).
+* **NVIDIA Driver Optimizations**: Applies `NVreg_InitializeSystemMemoryAllocations=0` (disables memory clearing for GPU allocations), `NVreg_DynamicPowerManagement=0x02` (mobile GPU power saving), and `NVreg_EnableS0ixPowerManagement=1` (S0ix idle power saving on supported laptops).
 
 ### ⏱️ Systemd: Service & System Management
 Systemd unit and configuration files for streamlined boot, resource management, and service control.

--- a/usr/lib/modprobe.d/nvidia.conf
+++ b/usr/lib/modprobe.d/nvidia.conf
@@ -1,10 +1,4 @@
 #
-# NVreg_UsePageAttributeTable=1 (Default 0) - Activating the better memory
-# management method (PAT). The PAT method creates a partition type table at a
-# specific address mapped inside the register and utilizes the memory
-# architecture and instruction set more efficiently and faster. If your system
-# can support this feature, it should improve CPU performance.
-#
 # NVreg_InitializeSystemMemoryAllocations=0 (Default 1) - Disables clearing
 # system memory allocation before using it for the GPU. Potentially improves
 # performance, but at the cost of increased security risks. Write "options
@@ -17,6 +11,5 @@
 # powered down during idle time.
 #
 #
-options nvidia NVreg_UsePageAttributeTable=1 \
-    NVreg_InitializeSystemMemoryAllocations=0 \
+options nvidia NVreg_InitializeSystemMemoryAllocations=0 \
     NVreg_DynamicPowerManagement=0x02


### PR DESCRIPTION
The parameter was dropped in NVIDIA driver 610 and only produced an ignored-module-parameter warning at boot.