### PR TITLE
iw-set-regdomain: broaden no-country zones, resolve aliases

### DIFF
--- a/usr/lib/iw-set-regdomain
+++ b/usr/lib/iw-set-regdomain
@@ -55,19 +55,30 @@ then
 	exit 1
 fi
 
+# Zones with no single associated country
+case "$ZONE" in
+	UTC|UCT|Universal|Zulu|GMT|GMT[+-]0|GMT0|Greenwich|Factory|posixrules|\
+	CET|EET|WET|MET|EST|MST|HST|EST5EDT|CST6CDT|MST7MDT|PST8PDT|\
+	Etc/*)
+		$LOGGER "Timezone is $ZONE, with no associated country. Not setting wireless regulatory domain."
+		exit 0
+		;;
+esac
+
+# Resolve backward-compat aliases (e.g. Asia/Calcutta) to their canonical name
+TZDATA_ZI=/usr/share/zoneinfo/tzdata.zi
+if [ -f "$TZDATA_ZI" ]
+then
+	CANON=$(awk -v z="$ZONE" '$1=="L" && $3==z {print $2; exit}' "$TZDATA_ZI")
+	[ -n "$CANON" ] && ZONE=$CANON
+fi
+
 COUNTRY=$(getcountry)
 
 if [ -z "$COUNTRY" ]
 then
-	case "$ZONE" in
-        UTC|UCT|Universal|Zulu|GMT|Etc/UTC|Etc/UCT|Etc/Universal|Etc/Zulu|Etc/GMT)
-            $LOGGER "Timezone is $ZONE, with no associated country. Not setting wireless regulatory domain."
-            exit 0
-            ;;
-    esac
-
-    $LOGGER -s "Could not determine country for $ZONE. Unable to set wireless regulatory domain."
-    exit 1
+	$LOGGER -s "Could not determine country for $ZONE. Unable to set wireless regulatory domain."
+	exit 1
 fi
 
 $LOGGER "Setting regulatory domain to $COUNTRY based on timezone ($ZONE)."


### PR DESCRIPTION
Fixes two papercuts in the timezone to regulatory-domain lookup.

**Broaden the no-country whitelist**

The old `case` block matched only 10 UTC/GMT aliases, so 46 other country-less zones fell through to `logger -s` + `exit 1`. They now exit 0 quietly.

**Resolve backward-compat aliases**

`zone.tab` only lists canonical `Region/City` names, so a user on a legacy alias like `Asia/Calcutta` got "Could not determine country" and no regdomain. Aliases are now canonicalized via tzdata's Link table (`/usr/share/zoneinfo/tzdata.zi`) before the lookup. The no-country whitelist is checked first, so generic zones like `CET` and `EST` still skip rather than being pinned to an arbitrary single country.

**Testing**

Swept all 598 `timedatectl list-timezones` entries against the real script:

- 542 resolve a country from `zone.tab`  (418 canonical + 124 via alias)
- 56 hit the graceful no-country exit
- 0 unhandled
