### PR TITLE
cachyos-bugreport: redact enumerated machine values

### DIFF
--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=../usr/bin/cachyos-bugreport.sh
+source "$repo_root/usr/bin/cachyos-bugreport.sh"
+original_collect_sensitive_values=$(declare -f collect_sensitive_values)
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+collect_sensitive_values() {
+    cat <<'EOF'
+<home-dir-redacted>	/home/alex
+<username-redacted>	alex
+<ip-address-redacted>	192.0.2.44
+<ip-address-redacted>	2001:db8::44
+<mac-address-redacted>	02:11:22:33:44:55
+<machine-id-redacted>	0123456789abcdef0123456789abcdef
+<uuid-redacted>	ABCD-1234
+<ssid-redacted>	cachyos
+<usb-serial-redacted>	CURRENT-USB-123
+EOF
+}
+
+LOG_FILENAME="$test_dir/report.log"
+cat >"$LOG_FILENAME" <<'EOF'
+uname: Linux cachyos 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
+repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
+firmware version 6.18.44.1
+Host Name: cachyos
+systemd: Set hostname to cachyos.
+home=/home/alex/config user=alex allocation=ok
+current IPv4=192.0.2.44 current IPv6=2001:db8::44
+MAC=02:11:22:33:44:55 machine=0123456789abcdef0123456789abcdef
+filesystem UUID=ABCD-1234 standard=123e4567-e89b-12d3-a456-426614174000 historical PARTUUID=DEAD-BEEF
+connected to cachyos; SerialNumber: CURRENT-USB-123
+old firewall SRC=198.51.100.22 DST=2001:db8::99 MAC=AA:BB:CC:DD:EE:FF
+old lease address=10.2.3.4 gateway=2001:db8::1
+old wifi SSID="Old Cafe" and access point 'Older Cafe'
+old device Serial Number: OLD-USB-456
+machine-id=abcdefabcdefabcdefabcdefabcdefab
+opened QUrl("file:///mnt/private/one") then QUrl("file:///home/alex/two") safely
+contact maintainer@example.org
+EOF
+
+redact >/dev/null
+
+cat >"$test_dir/expected.log" <<'EOF'
+uname: Linux <hostname-redacted> 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
+repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
+firmware version 6.18.44.1
+Host Name: <hostname-redacted>
+systemd: Set hostname to <hostname-redacted>.
+home=<home-dir-redacted>/config user=<username-redacted> allocation=ok
+current IPv4=<ip-address-redacted> current IPv6=<ip-address-redacted>
+MAC=<mac-address-redacted> machine=<machine-id-redacted>
+filesystem UUID=<uuid-redacted> standard=<uuid-redacted> historical PARTUUID=<uuid-redacted>
+connected to <ssid-redacted>; SerialNumber: <usb-serial-redacted>
+old firewall SRC=<ip-address-redacted> DST=<ip-address-redacted> MAC=<mac-address-redacted>
+old lease address=<ip-address-redacted> gateway=<ip-address-redacted>
+old wifi SSID=<ssid-redacted> and access point '<ssid-redacted>'
+old device Serial Number: <usb-serial-redacted>
+machine-id=<machine-id-redacted>
+opened QUrl("file://<path-redacted>") then QUrl("file://<path-redacted>") safely
+contact <email-address-redacted>
+EOF
+
+diff -u "$test_dir/expected.log" "$LOG_FILENAME"
+
+eval "$original_collect_sensitive_values"
+SUDO_USER=root
+ip() {
+    printf '%s\n' '2: eth0 inet 192.0.2.55/24 scope global eth0' '2: eth0 inet6 2001:db8::55/64 scope global'
+}
+lsblk() { printf '%s\n' 'MOCK-UUID'; }
+nmcli() { printf '%s\n' '802-11-wireless:Cafe:Lab'; }
+udevadm() { printf '%s\n' 'E: ID_SERIAL_SHORT=MOCK-USB'; }
+inventory=$(collect_sensitive_values)
+grep -Fxq $'<ip-address-redacted>\t192.0.2.55' <<<"$inventory"
+grep -Fxq $'<ip-address-redacted>\t2001:db8::55' <<<"$inventory"
+grep -Fxq $'<uuid-redacted>\tMOCK-UUID' <<<"$inventory"
+grep -Fxq $'<ssid-redacted>\tCafe:Lab' <<<"$inventory"
+grep -Fxq $'<usb-serial-redacted>\tMOCK-USB' <<<"$inventory"
+
+collect_sensitive_values() { :; }
+LOG_FILENAME="$test_dir/empty-inventory.log"
+printf '%s\n' 'plain diagnostic text remains intact' >"$LOG_FILENAME"
+redact >/dev/null
+grep -Fxq 'plain diagnostic text remains intact' "$LOG_FILENAME"
+
+printf '%s\n' 'bugreport redaction tests: PASS'

--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -10,7 +10,7 @@ original_collect_sensitive_values=$(declare -f collect_sensitive_values)
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
-# --- Test 1: Main redaction pass covering all sensitive data classes ---
+# --- Test 1: Main redaction pass covering all sensitive data classes & edge cases ---
 collect_sensitive_values() {
     cat <<'EOF'
 <home-dir-redacted>	/home/alex
@@ -55,8 +55,10 @@ pcieport 0000:00:1c.4: AER: Corrected error received
 NetworkManager: device eth0 connected; carrier on
 CPU0: Thermal 100 C
 AA:BB:CC:DD:EE:FF 11:22:33:44:55:66 22:33:44:55:66:77
-nfs: server 192.168.1.50 not responding
+route fe80:00:11:22:33:44:55:66 metric 100
+nfs: server 198.51.100.22 not responding
 Failed to connect to 10.0.0.5:8080
+WireGuard endpoint 203.0.113.5:51820
 EOF
 
 redact >/dev/null
@@ -84,16 +86,18 @@ xhci_hcd 0000:0e:00.0: xHCI Host Controller
 nvme nvme0: pci function 0000:10:00.0
 amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
 pcieport 0000:00:1c.4: AER: Corrected error received
-NetworkManager: device eth0 connected; carrier <ssid-redacted>
+NetworkManager: device eth0 connected; carrier on
 CPU0: Thermal 100 C
 <mac-address-redacted> <mac-address-redacted> <mac-address-redacted>
+route fe80:00:11:22:33:44:55:66 metric 100
 nfs: server <ip-address-redacted> not responding
 Failed to connect to <ip-address-redacted>
+WireGuard endpoint <ip-address-redacted>
 EOF
 
 diff -u "$test_dir/expected.log" "$LOG_FILENAME"
 
-# --- Test 2: Custom hostname (petes-laptop) redaction across non-fixed positions ---
+# --- Test 2: Custom hostname (petes-laptop) and Avahi conflict suffix (petes-laptop-2) ---
 collect_sensitive_values() {
     cat <<'EOF'
 <hostname-redacted>	petes-laptop
@@ -112,17 +116,17 @@ redact >/dev/null
 
 cat >"$test_dir/hostname-custom-expected.log" <<'EOF'
 NetworkManager[689]: <info> hostname changed from "localhost" to "<hostname-redacted>"
-avahi-daemon[702]: Host name conflict, retrying with petes-laptop-2
+avahi-daemon[702]: Host name conflict, retrying with <hostname-redacted>
 kernel: Linux version 7.1.6-1-cachyos (linux-cachyos@<hostname-redacted>) #1
 dbus-daemon: [session uid=1000 pid=900] on <hostname-redacted>
 EOF
 
 diff -u "$test_dir/hostname-custom-expected.log" "$LOG_FILENAME"
 
-# --- Test 3: Collection mock validations (filtering PCI BDF, nmcli SSID, user fallback) ---
+# --- Test 3: Collection mock validations (filtering PCI BDF, date/timestamp serials, nmcli contract, user detection) ---
 eval "$original_collect_sensitive_values"
 
-# Test udevadm PCI address / generic serial filtering
+# Test udevadm PCI address / generic / timestamp serial filtering
 SUDO_USER=root
 udevadm() {
     printf '%s\n' \
@@ -130,8 +134,12 @@ udevadm() {
         'E: ID_SERIAL_SHORT=0000:10:00.0' \
         'E: ID_SERIAL_SHORT=000000000' \
         'E: ID_SERIAL_SHORT=9876543210' \
+        'E: ID_SERIAL_SHORT=1234567890' \
         'E: ID_SERIAL_SHORT=0' \
-        'E: ID_SERIAL_SHORT=VALID-USB-DEVICE'
+        'E: ID_SERIAL_SHORT=202404073115' \
+        'E: ID_SERIAL_SHORT=20231122' \
+        'E: ID_SERIAL_SHORT=VALID-USB-DEVICE' \
+        'E: ID_SERIAL_SHORT=SN12345678'
 }
 ip() { :; }
 lsblk() { :; }
@@ -141,19 +149,25 @@ inventory=$(collect_sensitive_values)
 ! grep -q '0000:0e:00.0' <<<"$inventory"
 ! grep -q '000000000' <<<"$inventory"
 ! grep -q '9876543210' <<<"$inventory"
+! grep -q '202404073115' <<<"$inventory"
+! grep -q $'\t0$' <<<"$inventory"
 grep -Fxq $'<usb-serial-redacted>\tVALID-USB-DEVICE' <<<"$inventory"
+grep -Fxq $'<usb-serial-redacted>\tSN12345678' <<<"$inventory"
 
-# Test nmcli profile name and distinct SSID collection
+# Test nmcli contract with --escape no and SSID with colons
 nmcli() {
-    if [ "${1:-}" = "--terse" ]; then
+    if [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "--fields" ]; then
         printf '%s\n' '802-11-wireless:uuid-123:My Profile 1'
-    elif [ "${1:-}" = "-g" ]; then
-        printf '%s\n' 'Actual Broadcast SSID'
+    elif [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "-g" ] && [ "${5:-}" = "802-11-wireless.ssid" ]; then
+        printf '%s\n' 'Cafe:Lab'
+    else
+        echo "nmcli called with invalid arguments: $*" >&2
+        return 1
     fi
 }
 inventory=$(collect_sensitive_values)
 grep -Fxq $'<ssid-redacted>\tMy Profile 1' <<<"$inventory"
-grep -Fxq $'<ssid-redacted>\tActual Broadcast SSID' <<<"$inventory"
+grep -Fxq $'<ssid-redacted>\tCafe:Lab' <<<"$inventory"
 
 # Test user detection fallback with PKEXEC_UID
 unset SUDO_USER || true
@@ -172,7 +186,42 @@ inventory=$(collect_sensitive_values)
 grep -Fxq $'<username-redacted>\tpkexec_user' <<<"$inventory"
 grep -Fxq $'<home-dir-redacted>\t/home/pkexec_user' <<<"$inventory"
 
-# --- Test 4: Empty inventory degradation ---
+# --- Test 4: EXIT cleanup trap behavior ---
+trap_test_file="$test_dir/preexisting.log"
+touch "$trap_test_file"
+
+# Scenario A: Non-zero exit before bugreport() starts (CLEANUP_ON_ERROR=0) must preserve existing file
+LOG_FILENAME="$trap_test_file"
+CLEANUP_ON_ERROR=0
+(
+    exit_with_error() { return 1; }
+    exit_with_error || cleanup
+) || true
+[ -f "$trap_test_file" ]
+
+# Scenario B: Non-zero exit after bugreport() creates unredacted report (CLEANUP_ON_ERROR=1) must remove it
+LOG_FILENAME="$trap_test_file"
+CLEANUP_ON_ERROR=1
+(
+    exit_with_error() { return 1; }
+    exit_with_error || cleanup
+) || true
+[ ! -f "$trap_test_file" ]
+
+# Scenario C: Successful redact() disarms CLEANUP_ON_ERROR
+LOG_FILENAME="$test_dir/redacted_ok.log"
+printf '%s\n' 'some diagnostic line' >"$LOG_FILENAME"
+collect_sensitive_values() { :; }
+CLEANUP_ON_ERROR=1
+redact >/dev/null
+[ "$CLEANUP_ON_ERROR" -eq 0 ]
+(
+    exit_with_error() { return 1; }
+    exit_with_error || cleanup
+) || true
+[ -f "$LOG_FILENAME" ]
+
+# --- Test 5: Empty inventory degradation ---
 collect_sensitive_values() { :; }
 LOG_FILENAME="$test_dir/empty-inventory.log"
 printf '%s\n' 'plain diagnostic text remains intact' >"$LOG_FILENAME"

--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -10,17 +10,21 @@ original_collect_sensitive_values=$(declare -f collect_sensitive_values)
 test_dir=$(mktemp -d)
 trap 'rm -rf "$test_dir"' EXIT
 
+# --- Test 1: Main redaction pass covering all sensitive data classes ---
 collect_sensitive_values() {
     cat <<'EOF'
 <home-dir-redacted>	/home/alex
 <username-redacted>	alex
+<hostname-redacted>	cachyos
 <ip-address-redacted>	192.0.2.44
 <ip-address-redacted>	2001:db8::44
 <mac-address-redacted>	02:11:22:33:44:55
 <machine-id-redacted>	0123456789abcdef0123456789abcdef
 <uuid-redacted>	ABCD-1234
-<ssid-redacted>	cachyos
+<ssid-redacted>	cachyos-ap
+<ssid-redacted>	on
 <usb-serial-redacted>	CURRENT-USB-123
+<usb-serial-redacted>	0
 EOF
 }
 
@@ -28,21 +32,31 @@ LOG_FILENAME="$test_dir/report.log"
 cat >"$LOG_FILENAME" <<'EOF'
 uname: Linux cachyos 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
-firmware version 6.18.44.1
+firmware version 6.18.44.1 and bcdDevice 1.02.03.04
 Host Name: cachyos
 systemd: Set hostname to cachyos.
-home=/home/alex/config user=alex allocation=ok
+(linux-cachyos@cachyos)
+home=/home/alex/config user=alex allocation=ok /home/alexander
 current IPv4=192.0.2.44 current IPv6=2001:db8::44
 MAC=02:11:22:33:44:55 machine=0123456789abcdef0123456789abcdef
-filesystem UUID=ABCD-1234 standard=123e4567-e89b-12d3-a456-426614174000 historical PARTUUID=DEAD-BEEF
-connected to cachyos; SerialNumber: CURRENT-USB-123
-old firewall SRC=198.51.100.22 DST=2001:db8::99 MAC=AA:BB:CC:DD:EE:FF
+filesystem UUID=ABCD-1234 standard=123e4567-e89b-12d3-a456-426614174000 historical PARTUUID=DEAD-BEEF ID_FS_UUID=FEED-CAFE
+connected to cachyos-ap; SerialNumber: CURRENT-USB-123
+old firewall SRC=198.51.100.22 DST=2001:db8::99 MAC=00:11:22:33:44:55:66:77:88:99:aa:bb:08:00
 old lease address=10.2.3.4 gateway=2001:db8::1
 old wifi SSID="Old Cafe" and access point 'Older Cafe'
 old device Serial Number: OLD-USB-456
 machine-id=abcdefabcdefabcdefabcdefabcdefab
 opened QUrl("file:///mnt/private/one") then QUrl("file:///home/alex/two") safely
 contact maintainer@example.org
+xhci_hcd 0000:0e:00.0: xHCI Host Controller
+nvme nvme0: pci function 0000:10:00.0
+amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
+pcieport 0000:00:1c.4: AER: Corrected error received
+NetworkManager: device eth0 connected; carrier on
+CPU0: Thermal 100 C
+AA:BB:CC:DD:EE:FF 11:22:33:44:55:66 22:33:44:55:66:77
+nfs: server 192.168.1.50 not responding
+Failed to connect to 10.0.0.5:8080
 EOF
 
 redact >/dev/null
@@ -50,40 +64,115 @@ redact >/dev/null
 cat >"$test_dir/expected.log" <<'EOF'
 uname: Linux <hostname-redacted> 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
-firmware version 6.18.44.1
+firmware version 6.18.44.1 and bcdDevice 1.02.03.04
 Host Name: <hostname-redacted>
 systemd: Set hostname to <hostname-redacted>.
-home=<home-dir-redacted>/config user=<username-redacted> allocation=ok
+(linux-cachyos@<hostname-redacted>)
+home=<home-dir-redacted>/config user=<username-redacted> allocation=ok /home/alexander
 current IPv4=<ip-address-redacted> current IPv6=<ip-address-redacted>
 MAC=<mac-address-redacted> machine=<machine-id-redacted>
-filesystem UUID=<uuid-redacted> standard=<uuid-redacted> historical PARTUUID=<uuid-redacted>
+filesystem UUID=<uuid-redacted> standard=<uuid-redacted> historical PARTUUID=<uuid-redacted> ID_FS_UUID=<uuid-redacted>
 connected to <ssid-redacted>; SerialNumber: <usb-serial-redacted>
-old firewall SRC=<ip-address-redacted> DST=<ip-address-redacted> MAC=<mac-address-redacted>
+old firewall SRC=<ip-address-redacted> DST=<ip-address-redacted> MAC=<mac-address-redacted>:<mac-address-redacted>:08:00
 old lease address=<ip-address-redacted> gateway=<ip-address-redacted>
 old wifi SSID=<ssid-redacted> and access point '<ssid-redacted>'
 old device Serial Number: <usb-serial-redacted>
 machine-id=<machine-id-redacted>
 opened QUrl("file://<path-redacted>") then QUrl("file://<path-redacted>") safely
 contact <email-address-redacted>
+xhci_hcd 0000:0e:00.0: xHCI Host Controller
+nvme nvme0: pci function 0000:10:00.0
+amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
+pcieport 0000:00:1c.4: AER: Corrected error received
+NetworkManager: device eth0 connected; carrier <ssid-redacted>
+CPU0: Thermal 100 C
+<mac-address-redacted> <mac-address-redacted> <mac-address-redacted>
+nfs: server <ip-address-redacted> not responding
+Failed to connect to <ip-address-redacted>
 EOF
 
 diff -u "$test_dir/expected.log" "$LOG_FILENAME"
 
-eval "$original_collect_sensitive_values"
-SUDO_USER=root
-ip() {
-    printf '%s\n' '2: eth0 inet 192.0.2.55/24 scope global eth0' '2: eth0 inet6 2001:db8::55/64 scope global'
+# --- Test 2: Custom hostname (petes-laptop) redaction across non-fixed positions ---
+collect_sensitive_values() {
+    cat <<'EOF'
+<hostname-redacted>	petes-laptop
+EOF
 }
-lsblk() { printf '%s\n' 'MOCK-UUID'; }
-nmcli() { printf '%s\n' '802-11-wireless:Cafe:Lab'; }
-udevadm() { printf '%s\n' 'E: ID_SERIAL_SHORT=MOCK-USB'; }
-inventory=$(collect_sensitive_values)
-grep -Fxq $'<ip-address-redacted>\t192.0.2.55' <<<"$inventory"
-grep -Fxq $'<ip-address-redacted>\t2001:db8::55' <<<"$inventory"
-grep -Fxq $'<uuid-redacted>\tMOCK-UUID' <<<"$inventory"
-grep -Fxq $'<ssid-redacted>\tCafe:Lab' <<<"$inventory"
-grep -Fxq $'<usb-serial-redacted>\tMOCK-USB' <<<"$inventory"
 
+LOG_FILENAME="$test_dir/hostname-custom.log"
+cat >"$LOG_FILENAME" <<'EOF'
+NetworkManager[689]: <info> hostname changed from "localhost" to "petes-laptop"
+avahi-daemon[702]: Host name conflict, retrying with petes-laptop-2
+kernel: Linux version 7.1.6-1-cachyos (linux-cachyos@petes-laptop) #1
+dbus-daemon: [session uid=1000 pid=900] on petes-laptop
+EOF
+
+redact >/dev/null
+
+cat >"$test_dir/hostname-custom-expected.log" <<'EOF'
+NetworkManager[689]: <info> hostname changed from "localhost" to "<hostname-redacted>"
+avahi-daemon[702]: Host name conflict, retrying with petes-laptop-2
+kernel: Linux version 7.1.6-1-cachyos (linux-cachyos@<hostname-redacted>) #1
+dbus-daemon: [session uid=1000 pid=900] on <hostname-redacted>
+EOF
+
+diff -u "$test_dir/hostname-custom-expected.log" "$LOG_FILENAME"
+
+# --- Test 3: Collection mock validations (filtering PCI BDF, nmcli SSID, user fallback) ---
+eval "$original_collect_sensitive_values"
+
+# Test udevadm PCI address / generic serial filtering
+SUDO_USER=root
+udevadm() {
+    printf '%s\n' \
+        'E: ID_SERIAL_SHORT=0000:0e:00.0' \
+        'E: ID_SERIAL_SHORT=0000:10:00.0' \
+        'E: ID_SERIAL_SHORT=000000000' \
+        'E: ID_SERIAL_SHORT=9876543210' \
+        'E: ID_SERIAL_SHORT=0' \
+        'E: ID_SERIAL_SHORT=VALID-USB-DEVICE'
+}
+ip() { :; }
+lsblk() { :; }
+nmcli() { :; }
+
+inventory=$(collect_sensitive_values)
+! grep -q '0000:0e:00.0' <<<"$inventory"
+! grep -q '000000000' <<<"$inventory"
+! grep -q '9876543210' <<<"$inventory"
+grep -Fxq $'<usb-serial-redacted>\tVALID-USB-DEVICE' <<<"$inventory"
+
+# Test nmcli profile name and distinct SSID collection
+nmcli() {
+    if [ "${1:-}" = "--terse" ]; then
+        printf '%s\n' '802-11-wireless:uuid-123:My Profile 1'
+    elif [ "${1:-}" = "-g" ]; then
+        printf '%s\n' 'Actual Broadcast SSID'
+    fi
+}
+inventory=$(collect_sensitive_values)
+grep -Fxq $'<ssid-redacted>\tMy Profile 1' <<<"$inventory"
+grep -Fxq $'<ssid-redacted>\tActual Broadcast SSID' <<<"$inventory"
+
+# Test user detection fallback with PKEXEC_UID
+unset SUDO_USER || true
+export PKEXEC_UID=1000
+id() {
+    if [ "$1" = "-nu" ] && [ "$2" = "1000" ]; then
+        printf '%s\n' 'pkexec_user'
+    fi
+}
+getent() {
+    if [ "$1" = "passwd" ] && [ "$2" = "pkexec_user" ]; then
+        printf '%s\n' 'pkexec_user:x:1000:1000::/home/pkexec_user:/bin/bash'
+    fi
+}
+inventory=$(collect_sensitive_values)
+grep -Fxq $'<username-redacted>\tpkexec_user' <<<"$inventory"
+grep -Fxq $'<home-dir-redacted>\t/home/pkexec_user' <<<"$inventory"
+
+# --- Test 4: Empty inventory degradation ---
 collect_sensitive_values() { :; }
 LOG_FILENAME="$test_dir/empty-inventory.log"
 printf '%s\n' 'plain diagnostic text remains intact' >"$LOG_FILENAME"

--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -22,9 +22,10 @@ collect_sensitive_values() {
 <machine-id-redacted>	0123456789abcdef0123456789abcdef
 <uuid-redacted>	ABCD-1234
 <ssid-redacted>	cachyos-ap
-<ssid-redacted>	on
+<ssid-redacted>	Lab!
+<ssid-redacted>	-foo-
+<ssid-redacted>	Cafe:Lab
 <usb-serial-redacted>	CURRENT-USB-123
-<usb-serial-redacted>	0
 EOF
 }
 
@@ -33,14 +34,22 @@ cat >"$LOG_FILENAME" <<'EOF'
 uname: Linux cachyos 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
 firmware version 6.18.44.1 and bcdDevice 1.02.03.04
+Linux diagnostic release 6.18.44.1
+firmware updater contacted 198.51.100.23
+revision service endpoint 203.0.113.7
+invalid IP 999.999.999.999
 Host Name: cachyos
 systemd: Set hostname to cachyos.
 (linux-cachyos@cachyos)
 home=/home/alex/config user=alex allocation=ok /home/alexander
 current IPv4=192.0.2.44 current IPv6=2001:db8::44
 MAC=02:11:22:33:44:55 machine=0123456789abcdef0123456789abcdef
+mac:AA:BB:CC:DD:EE:FF and mac: BB:CC:DD:EE:FF:00
 filesystem UUID=ABCD-1234 standard=123e4567-e89b-12d3-a456-426614174000 historical PARTUUID=DEAD-BEEF ID_FS_UUID=FEED-CAFE
 connected to cachyos-ap; SerialNumber: CURRENT-USB-123
+wifi connected to Lab! in the office
+wifi connected to -foo- in the office
+wifi connected to Cafe:Lab in the office
 old firewall SRC=198.51.100.22 DST=2001:db8::99 MAC=00:11:22:33:44:55:66:77:88:99:aa:bb:08:00
 old lease address=10.2.3.4 gateway=2001:db8::1
 old wifi SSID="Old Cafe" and access point 'Older Cafe'
@@ -53,6 +62,7 @@ nvme nvme0: pci function 0000:10:00.0
 amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
 pcieport 0000:00:1c.4: AER: Corrected error received
 NetworkManager: device eth0 connected; carrier on
+NetworkManager: the interface connected normally
 CPU0: Thermal 100 C
 AA:BB:CC:DD:EE:FF 11:22:33:44:55:66 22:33:44:55:66:77
 route fe80:00:11:22:33:44:55:66 metric 100
@@ -67,14 +77,22 @@ cat >"$test_dir/expected.log" <<'EOF'
 uname: Linux <hostname-redacted> 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
 firmware version 6.18.44.1 and bcdDevice 1.02.03.04
+Linux diagnostic release 6.18.44.1
+firmware updater contacted <ip-address-redacted>
+revision service endpoint <ip-address-redacted>
+invalid IP 999.999.999.999
 Host Name: <hostname-redacted>
 systemd: Set hostname to <hostname-redacted>.
 (linux-cachyos@<hostname-redacted>)
 home=<home-dir-redacted>/config user=<username-redacted> allocation=ok /home/alexander
 current IPv4=<ip-address-redacted> current IPv6=<ip-address-redacted>
 MAC=<mac-address-redacted> machine=<machine-id-redacted>
+mac:<mac-address-redacted> and mac: <mac-address-redacted>
 filesystem UUID=<uuid-redacted> standard=<uuid-redacted> historical PARTUUID=<uuid-redacted> ID_FS_UUID=<uuid-redacted>
 connected to <ssid-redacted>; SerialNumber: <usb-serial-redacted>
+wifi connected to <ssid-redacted> in the office
+wifi connected to <ssid-redacted> in the office
+wifi connected to <ssid-redacted> in the office
 old firewall SRC=<ip-address-redacted> DST=<ip-address-redacted> MAC=<mac-address-redacted>:<mac-address-redacted>:08:00
 old lease address=<ip-address-redacted> gateway=<ip-address-redacted>
 old wifi SSID=<ssid-redacted> and access point '<ssid-redacted>'
@@ -87,6 +105,7 @@ nvme nvme0: pci function 0000:10:00.0
 amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
 pcieport 0000:00:1c.4: AER: Corrected error received
 NetworkManager: device eth0 connected; carrier on
+NetworkManager: the interface connected normally
 CPU0: Thermal 100 C
 <mac-address-redacted> <mac-address-redacted> <mac-address-redacted>
 route fe80:00:11:22:33:44:55:66 metric 100
@@ -154,14 +173,14 @@ inventory=$(collect_sensitive_values)
 grep -Fxq $'<usb-serial-redacted>\tVALID-USB-DEVICE' <<<"$inventory"
 grep -Fxq $'<usb-serial-redacted>\tSN12345678' <<<"$inventory"
 
-# Test nmcli contract with --escape no and SSID with colons
+# Test complete nmcli contract: 7 args for list, 8 args for ssid show "$uuid"
 nmcli() {
-    if [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "--fields" ]; then
+    if [ "$#" -eq 7 ] && [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "--fields" ] && [ "${5:-}" = "TYPE,UUID,NAME" ] && [ "${6:-}" = "connection" ] && [ "${7:-}" = "show" ]; then
         printf '%s\n' '802-11-wireless:uuid-123:My Profile 1'
-    elif [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "-g" ] && [ "${5:-}" = "802-11-wireless.ssid" ]; then
+    elif [ "$#" -eq 8 ] && [ "${1:-}" = "--terse" ] && [ "${2:-}" = "--escape" ] && [ "${3:-}" = "no" ] && [ "${4:-}" = "-g" ] && [ "${5:-}" = "802-11-wireless.ssid" ] && [ "${6:-}" = "connection" ] && [ "${7:-}" = "show" ] && [ "${8:-}" = "uuid-123" ]; then
         printf '%s\n' 'Cafe:Lab'
     else
-        echo "nmcli called with invalid arguments: $*" >&2
+        echo "nmcli mock failed: unexpected arguments ($#): $*" >&2
         return 1
     fi
 }

--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -25,6 +25,7 @@ collect_sensitive_values() {
 <ssid-redacted>	Lab!
 <ssid-redacted>	-foo-
 <ssid-redacted>	Cafe:Lab
+<ssid-redacted>	this
 <usb-serial-redacted>	CURRENT-USB-123
 EOF
 }
@@ -35,9 +36,12 @@ uname: Linux cachyos 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
 firmware version 6.18.44.1 and bcdDevice 1.02.03.04
 Linux diagnostic release 6.18.44.1
+Linux kernel 6.18.44.1 loaded
+Linux version is 6.18.44.1
+firmware: 198.51.100.24 download mirror unavailable
 firmware updater contacted 198.51.100.23
 revision service endpoint 203.0.113.7
-invalid IP 999.999.999.999
+address=999.999.999.999
 Host Name: cachyos
 systemd: Set hostname to cachyos.
 (linux-cachyos@cachyos)
@@ -45,11 +49,15 @@ home=/home/alex/config user=alex allocation=ok /home/alexander
 current IPv4=192.0.2.44 current IPv6=2001:db8::44
 MAC=02:11:22:33:44:55 machine=0123456789abcdef0123456789abcdef
 mac:AA:BB:CC:DD:EE:FF and mac: BB:CC:DD:EE:FF:00
+Mac:11:22:33:44:55:66 and wifi_mac:22:33:44:55:66:77
+addr=00:11:22:33:44:55:66 and device_hwaddr=33:44:55:66:77:88
 filesystem UUID=ABCD-1234 standard=123e4567-e89b-12d3-a456-426614174000 historical PARTUUID=DEAD-BEEF ID_FS_UUID=FEED-CAFE
 connected to cachyos-ap; SerialNumber: CURRENT-USB-123
-wifi connected to Lab! in the office
+wifi saw Lab! Lab! nearby
+wifi saw Cafe:Lab Cafe:Lab nearby
+NetworkManager: association with Lab! established
 wifi connected to -foo- in the office
-wifi connected to Cafe:Lab in the office
+wifi this interface connected normally
 old firewall SRC=198.51.100.22 DST=2001:db8::99 MAC=00:11:22:33:44:55:66:77:88:99:aa:bb:08:00
 old lease address=10.2.3.4 gateway=2001:db8::1
 old wifi SSID="Old Cafe" and access point 'Older Cafe'
@@ -62,13 +70,13 @@ nvme nvme0: pci function 0000:10:00.0
 amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
 pcieport 0000:00:1c.4: AER: Corrected error received
 NetworkManager: device eth0 connected; carrier on
-NetworkManager: the interface connected normally
 CPU0: Thermal 100 C
 AA:BB:CC:DD:EE:FF 11:22:33:44:55:66 22:33:44:55:66:77
 route fe80:00:11:22:33:44:55:66 metric 100
 nfs: server 198.51.100.22 not responding
 Failed to connect to 10.0.0.5:8080
 WireGuard endpoint 203.0.113.5:51820
+invalid IP 999.999.999.999
 EOF
 
 redact >/dev/null
@@ -78,9 +86,12 @@ uname: Linux <hostname-redacted> 7.1.6-1-cachyos #1 SMP PREEMPT_DYNAMIC x86_64 G
 repo cachyos-v4 package linux-cachyos kernel 7.1.6-1-cachyos
 firmware version 6.18.44.1 and bcdDevice 1.02.03.04
 Linux diagnostic release 6.18.44.1
+Linux kernel 6.18.44.1 loaded
+Linux version is 6.18.44.1
+firmware: <ip-address-redacted> download mirror unavailable
 firmware updater contacted <ip-address-redacted>
 revision service endpoint <ip-address-redacted>
-invalid IP 999.999.999.999
+address=999.999.999.999
 Host Name: <hostname-redacted>
 systemd: Set hostname to <hostname-redacted>.
 (linux-cachyos@<hostname-redacted>)
@@ -88,11 +99,15 @@ home=<home-dir-redacted>/config user=<username-redacted> allocation=ok /home/ale
 current IPv4=<ip-address-redacted> current IPv6=<ip-address-redacted>
 MAC=<mac-address-redacted> machine=<machine-id-redacted>
 mac:<mac-address-redacted> and mac: <mac-address-redacted>
+Mac:<mac-address-redacted> and wifi_mac:<mac-address-redacted>
+addr=00:11:22:33:44:55:66 and device_hwaddr=<mac-address-redacted>
 filesystem UUID=<uuid-redacted> standard=<uuid-redacted> historical PARTUUID=<uuid-redacted> ID_FS_UUID=<uuid-redacted>
 connected to <ssid-redacted>; SerialNumber: <usb-serial-redacted>
+wifi saw <ssid-redacted> <ssid-redacted> nearby
+wifi saw <ssid-redacted> <ssid-redacted> nearby
+NetworkManager: association with <ssid-redacted> established
 wifi connected to <ssid-redacted> in the office
-wifi connected to <ssid-redacted> in the office
-wifi connected to <ssid-redacted> in the office
+wifi this interface connected normally
 old firewall SRC=<ip-address-redacted> DST=<ip-address-redacted> MAC=<mac-address-redacted>:<mac-address-redacted>:08:00
 old lease address=<ip-address-redacted> gateway=<ip-address-redacted>
 old wifi SSID=<ssid-redacted> and access point '<ssid-redacted>'
@@ -105,13 +120,13 @@ nvme nvme0: pci function 0000:10:00.0
 amdgpu 0000:7a:00.3: amdgpu: Fetched VBIOS from VFCT
 pcieport 0000:00:1c.4: AER: Corrected error received
 NetworkManager: device eth0 connected; carrier on
-NetworkManager: the interface connected normally
 CPU0: Thermal 100 C
 <mac-address-redacted> <mac-address-redacted> <mac-address-redacted>
 route fe80:00:11:22:33:44:55:66 metric 100
 nfs: server <ip-address-redacted> not responding
 Failed to connect to <ip-address-redacted>
 WireGuard endpoint <ip-address-redacted>
+invalid IP 999.999.999.999
 EOF
 
 diff -u "$test_dir/expected.log" "$LOG_FILENAME"

--- a/tests/test-bugreport-redaction.sh
+++ b/tests/test-bugreport-redaction.sh
@@ -262,4 +262,45 @@ printf '%s\n' 'plain diagnostic text remains intact' >"$LOG_FILENAME"
 redact >/dev/null
 grep -Fxq 'plain diagnostic text remains intact' "$LOG_FILENAME"
 
+# --- Test 6: Collector failures must fail closed before upload can be reached ---
+for failure_mode in immediate partial; do
+    LOG_FILENAME="$test_dir/collector-$failure_mode.log"
+    printf 'private WIFI-%s\n' "$failure_mode" >"$LOG_FILENAME"
+
+    if [ "$failure_mode" = immediate ]; then
+        collect_sensitive_values() { return 1; }
+    else
+        collect_sensitive_values() {
+            printf '%s\t%s\n' '<ssid-redacted>' WIFI-PARTIAL
+            return 1
+        }
+    fi
+
+    CLEANUP_ON_ERROR=1
+    if ( trap cleanup EXIT; redact >/dev/null ); then
+        echo "collector failure unexpectedly succeeded: $failure_mode" >&2
+        exit 1
+    fi
+    [ ! -f "$LOG_FILENAME" ]
+done
+
+# --- Test 7: Ignored final candidates do not make valid emission fail ---
+if ! emitted_values=$(printf '%s\n' valid-value no '' | emit_sensitive_values '<test-redacted>'); then
+    echo 'emit_sensitive_values rejected ignored final candidates' >&2
+    exit 1
+fi
+grep -Fxq $'<test-redacted>\tvalid-value' <<<"$emitted_values"
+[ "$(printf '%s\n' "$emitted_values" | wc -l)" -eq 1 ]
+
+# --- Test 8: Successful collection and redaction still work after fail-closed checks ---
+collect_sensitive_values() {
+    printf '%s\t%s\n' '<ssid-redacted>' WIFI-SUCCESS
+}
+LOG_FILENAME="$test_dir/success-after-failure.log"
+printf 'connected to WIFI-SUCCESS\n' >"$LOG_FILENAME"
+CLEANUP_ON_ERROR=1
+redact >/dev/null
+grep -Fxq 'connected to <ssid-redacted>' "$LOG_FILENAME"
+[ "$CLEANUP_ON_ERROR" -eq 0 ]
+
 printf '%s\n' 'bugreport redaction tests: PASS'

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -96,11 +96,11 @@ $(dmesg)
 ____________________________________________
 journalctl of current boot
 
-$(journalctl -b -p 4..1)
+$(journalctl --no-hostname -b -p 4..1)
 ____________________________________________
 journalctl of previous boot
 
-$(journalctl -b -1 -p 4..1 2>/dev/null || echo "No previous boot log available")
+$(journalctl --no-hostname -b -1 -p 4..1 2>/dev/null || echo "No previous boot log available")
 ____________________________________________
 
 Installed packages
@@ -110,39 +110,109 @@ $(get_installed_packages)
 EOF
 }
 
+emit_sensitive_values() {
+    local replacement="$1"
+    local value
+
+    while IFS= read -r value; do
+        [ -n "$value" ] && printf '%s\t%s\n' "$replacement" "$value"
+    done
+}
+
+collect_sensitive_values() {
+    local real_user="${SUDO_USER:-}"
+    local address_file
+    local machine_id_file
+
+    if [ -n "$real_user" ] && [ "$real_user" != "root" ]; then
+        { getent passwd "$real_user" 2>/dev/null || true; } |
+            cut -d: -f6 |
+            emit_sensitive_values '<home-dir-redacted>'
+        printf '%s\n' "$real_user" | emit_sensitive_values '<username-redacted>'
+    fi
+
+    if command -v ip >/dev/null; then
+        { ip -o address show 2>/dev/null || true; } |
+            awk '$2 != "lo" && ($3 == "inet" || $3 == "inet6") {sub(/\/.*/, "", $4); print $4}' |
+            emit_sensitive_values '<ip-address-redacted>'
+    fi
+
+    for address_file in /sys/class/net/*/address; do
+        if [ -r "$address_file" ]; then
+            sed '/^00:00:00:00:00:00$/d' "$address_file"
+        fi
+    done | emit_sensitive_values '<mac-address-redacted>'
+
+    for machine_id_file in /etc/machine-id /var/lib/dbus/machine-id; do
+        if [ -r "$machine_id_file" ]; then
+            sed -n '1p' "$machine_id_file"
+        fi
+    done | sort -u | emit_sensitive_values '<machine-id-redacted>'
+
+    if command -v lsblk >/dev/null; then
+        { lsblk -rno UUID 2>/dev/null || true; } | emit_sensitive_values '<uuid-redacted>'
+    fi
+
+    if command -v nmcli >/dev/null; then
+        { nmcli --terse --escape no --fields TYPE,NAME connection show 2>/dev/null || true; } |
+            sed -nE 's/^(802-11-wireless|wifi)://p' |
+            emit_sensitive_values '<ssid-redacted>'
+    fi
+
+    if command -v udevadm >/dev/null; then
+        { udevadm info --export-db 2>/dev/null || true; } |
+            sed -n 's/^E: ID_SERIAL_SHORT=//p' |
+            emit_sensitive_values '<usb-serial-redacted>'
+    fi
+}
+
 redact() {
     echo "Redacting personal information..."
 
     local sed_args=()
+    local replacement
+    local value
 
-    # Escape a literal string for use in a sed pattern (] must be first in class)
-    sed_escape() { printf '%s\n' "$1" | sed 's/[][\\.^$*|]/\\&/g'; }
+    # Escape a literal string for use in an extended sed pattern.
+    sed_escape() { printf '%s\n' "$1" | sed 's/[][\\.^$*+?(){}|]/\\&/g'; }
 
-    # Redact hostname (appears in uname, dmesg, journalctl)
-    local hn
-    hn=$(hostname)
-    sed_args+=(-e "s|\b$(sed_escape "$hn")\b|<hostname-redacted>|g")
+    while IFS=$'\t' read -r replacement value; do
+        [ -n "$value" ] || continue
+        if [ "$replacement" = '<username-redacted>' ]; then
+            sed_args+=(-e "s|\\b$(sed_escape "$value")\\b|${replacement}|g")
+        elif [ "$replacement" = '<ssid-redacted>' ]; then
+            sed_args+=(-e "/(SSID|ssid|access point|connected|connection|NetworkManager|wifi|Wi-Fi)/ s|$(sed_escape "$value")|${replacement}|g")
+        else
+            sed_args+=(-e "s|$(sed_escape "$value")|${replacement}|g")
+        fi
+    done < <(collect_sensitive_values)
 
-    # Redact real username and home directory (SUDO_USER is set when run via sudo)
-    local real_user="${SUDO_USER:-}"
-    if [ -n "$real_user" ] && [ "$real_user" != "root" ]; then
-        local escaped_user
-        escaped_user=$(sed_escape "$real_user")
-        sed_args+=(-e "s|/home/${escaped_user}\b|<home-dir-redacted>|g")
-        sed_args+=(-e "s|\b${escaped_user}\b|<username-redacted>|g")
-    fi
+    # Hostnames occur in fixed report fields. Avoid replacing generic hostnames in
+    # useful strings such as linux-cachyos and cachyos-v4.
+    sed_args+=(-e 's#^(uname: [^[:space:]]+[[:space:]]+)[^[:space:]]+#\1<hostname-redacted>#')
+    sed_args+=(-e 's#((hostname|Host Name)[=:][[:space:]]*)[^[:space:]]+#\1<hostname-redacted>#g')
+    sed_args+=(-e 's#((Set hostname to|hostname set to)[[:space:]]+)[^[:space:].]+#\1<hostname-redacted>#gI')
 
-    # Redact IPv4 addresses (inxi -z handles its own output; this covers dmesg/journal)
-    sed_args+=(-e 's/\b\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}\b/<ipv4-redacted>/g')
+    # Previous-boot values may no longer be present on the machine. Redact only
+    # structured network, Wi-Fi and USB fields instead of guessing globally.
+    sed_args+=(-e 's#\b(SRC|DST)=[^[:space:]]+#\1=<ip-address-redacted>#g')
+    sed_args+=(-e 's#((ip_address|address|gateway|nameserver)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
+    sed_args+=(-e 's#((ip_address|address|gateway|nameserver)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
+    sed_args+=(-e "s#((SSID|ssid)[=:][[:space:]]*)(\"[^\"]*\"|'[^']*'|[^[:space:]]+)#\\1<ssid-redacted>#g")
+    sed_args+=(-e "s#((access point)[[:space:]]+)'[^']*'#\\1'<ssid-redacted>'#g")
+    sed_args+=(-e 's#((SerialNumber|Serial Number|ID_SERIAL_SHORT)[=:][[:space:]]*)[^[:space:]]+#\1<usb-serial-redacted>#g')
+    sed_args+=(-e 's#((machine-id|Machine ID)[=:][[:space:]]*)[[:xdigit:]]{32}#\1<machine-id-redacted>#g')
 
-    # Redact MAC addresses (fallback for anything inxi -z may have missed)
-    sed_args+=(-e 's/\b\([0-9a-fA-F]\{2\}:\)\{5\}[0-9a-fA-F]\{2\}\b/<mac-address-redacted>/g')
-
-    # Redact email addresses
-    sed_args+=(-e 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/<email-address-redacted>/g')
+    # These formats are distinctive, or explicitly requested for all sections.
+    sed_args+=(-e 's#(^|[^[:xdigit:]:])([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^[:xdigit:]:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b#<uuid-redacted>#g')
+    sed_args+=(-e 's#\b((PART)?UUID=)[0-9A-Fa-f-]+#\1<uuid-redacted>#g')
+    sed_args+=(-e 's#(/dev/disk/by-uuid/)[^[:space:]]+#\1<uuid-redacted>#g')
+    sed_args+=(-e 's#"file://[^"]*"#"file://<path-redacted>"#g')
+    sed_args+=(-e 's#[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}#<email-address-redacted>#g')
 
     # Single sed pass for all substitutions
-    sed -i "${sed_args[@]}" "$LOG_FILENAME"
+    sed -Ei "${sed_args[@]}" "$LOG_FILENAME"
 }
 
 upload() {
@@ -155,9 +225,11 @@ upload() {
 
 }
 
-check_root
-check_oldlog
-check_wpermission
-bugreport
-redact
-upload
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    check_root
+    check_oldlog
+    check_wpermission
+    bugreport
+    redact
+    upload
+fi

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -110,9 +110,11 @@ $(get_installed_packages)
 EOF
 }
 
+CLEANUP_ON_ERROR=0
+
 cleanup() {
     local exit_code=$?
-    if [ $exit_code -ne 0 ] && [ -n "${LOG_FILENAME:-}" ] && [ -f "$LOG_FILENAME" ]; then
+    if [ $exit_code -ne 0 ] && [ "${CLEANUP_ON_ERROR:-0}" -eq 1 ] && [ -n "${LOG_FILENAME:-}" ] && [ -f "$LOG_FILENAME" ]; then
         rm -f "$LOG_FILENAME" 2>/dev/null || true
     fi
 }
@@ -122,7 +124,7 @@ emit_sensitive_values() {
     local value
 
     while IFS= read -r value; do
-        [ -n "$value" ] && printf '%s\t%s\n' "$replacement" "$value"
+        [ -n "$value" ] && [ "${#value}" -ge 3 ] && printf '%s\t%s\n' "$replacement" "$value"
     done
 }
 
@@ -176,10 +178,10 @@ collect_sensitive_values() {
     if command -v nmcli >/dev/null; then
         local uuid name ssid
         while IFS=: read -r uuid name; do
-            [ -n "$name" ] && printf '%s\n' "$name"
+            [ -n "$name" ] && [ "${#name}" -ge 3 ] && printf '%s\n' "$name"
             if [ -n "$uuid" ]; then
-                ssid="$(nmcli -g 802-11-wireless.ssid connection show "$uuid" 2>/dev/null || true)"
-                [ -n "$ssid" ] && printf '%s\n' "$ssid"
+                ssid="$(nmcli --terse --escape no -g 802-11-wireless.ssid connection show "$uuid" 2>/dev/null || true)"
+                [ -n "$ssid" ] && [ "${#ssid}" -ge 3 ] && printf '%s\n' "$ssid"
             fi
         done < <({ nmcli --terse --escape no --fields TYPE,UUID,NAME connection show 2>/dev/null || true; } | sed -nE 's/^(802-11-wireless|wifi)://p') |
             emit_sensitive_values '<ssid-redacted>'
@@ -188,7 +190,7 @@ collect_sensitive_values() {
     if command -v udevadm >/dev/null; then
         { udevadm info --export-db 2>/dev/null || true; } |
             sed -n 's/^E: ID_SERIAL_SHORT=//p' |
-            grep -Ev '^[0-9a-fA-F]{2,4}:|^[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$|^0+$|^[0-9]{1,2}$|^9876543210$|^1234567890$' |
+            grep -Ev '^[0-9a-fA-F]{2,4}:|\.[0-9a-fA-F]$|^0+$|^[0-9]{1,3}$|^(.)\1+$|^123456|^987654|^012345|^(19|20)[0-9]{6,}$' |
             emit_sensitive_values '<usb-serial-redacted>'
     fi
 }
@@ -206,17 +208,17 @@ redact() {
 
     while IFS=$'\t' read -r replacement value; do
         [ -n "$value" ] || continue
+        [ "${#value}" -ge 3 ] || continue
         if [ "$replacement" = '<username-redacted>' ]; then
             sed_args+=(-e "s#\\b$(sed_escape "$value")\\b#${replacement}#g")
         elif [ "$replacement" = '<hostname-redacted>' ]; then
-            sed_args+=(-e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\2#g" \
-                       -e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\2#g")
+            sed_args+=(-e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g" \
+                       -e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g")
         elif [ "$replacement" = '<ssid-redacted>' ]; then
-            sed_args+=(-e "/(SSID|ssid|access point|connected|connection|NetworkManager|wifi|Wi-Fi)/ s#\\b$(sed_escape "$value")\\b#${replacement}#g")
+            sed_args+=(-e "/(SSID|ssid|access point|connected to|connection|NetworkManager|wifi|Wi-Fi)/ s#\\b$(sed_escape "$value")\\b#${replacement}#g")
         elif [ "$replacement" = '<home-dir-redacted>' ]; then
             sed_args+=(-e "s#$(sed_escape "$value")\\b#${replacement}#g")
         else
-            [ "${#value}" -ge 3 ] || continue
             sed_args+=(-e "s#\\b$(sed_escape "$value")\\b#${replacement}#g")
         fi
     done < <(collect_sensitive_values)
@@ -232,15 +234,18 @@ redact() {
     sed_args+=(-e 's#\b(SRC|DST)=[^[:space:]]+#\1=<ip-address-redacted>#g')
     sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
     sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
-    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b(10\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168|100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])|169\.254)\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]+)?\b#<ip-address-redacted>#g')
-    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b[0-9]{1,3}(\.[0-9]{1,3}){3}:[0-9]{2,5}\b#<ip-address-redacted>#g')
+    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b([0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]+)?\b#<ip-address-redacted>#g')
     sed_args+=(-e "s#((SSID|ssid)[=:][[:space:]]*)(\"[^\"]*\"|'[^']*'|[^[:space:]]+)#\\1<ssid-redacted>#g")
     sed_args+=(-e "s#((access point)[[:space:]]+)'[^']*'#\\1'<ssid-redacted>'#g")
     sed_args+=(-e 's#((SerialNumber|Serial Number|ID_SERIAL_SHORT)[=:][[:space:]]*)[^[:space:]]+#\1<usb-serial-redacted>#g')
     sed_args+=(-e 's#((machine-id|Machine ID)[=:][[:space:]]*)[[:xdigit:]]{32}#\1<machine-id-redacted>#g')
 
-    # These formats are distinctive, or explicitly requested for all sections.
-    sed_args+=(-e 's#\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b#<mac-address-redacted>#g')
+    # Netfilter MAC= chains + standalone MAC addresses (ignoring longer colon-hex chains)
+    sed_args+=(-e 's#\bMAC=([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}#MAC=<mac-address-redacted>:<mac-address-redacted>#g')
+    sed_args+=(-e 's#(^|[^:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#(^|[^:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^:]|$)#\1<mac-address-redacted>\3#g')
+
+    # UUIDs, URLs, Email
     sed_args+=(-e 's#\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b#<uuid-redacted>#g')
     sed_args+=(-e 's#(^|[^a-zA-Z0-9])((PART|ID_FS_)?UUID=)[0-9A-Fa-f-]+#\1\2<uuid-redacted>#g')
     sed_args+=(-e 's#(/dev/disk/by-uuid/)[^[:space:]]+#\1<uuid-redacted>#g')
@@ -249,6 +254,7 @@ redact() {
 
     # Single sed pass for all substitutions
     sed -Ei "${sed_args[@]}" "$LOG_FILENAME"
+    CLEANUP_ON_ERROR=0
 }
 
 upload() {
@@ -266,6 +272,7 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
     check_root
     check_oldlog
     check_wpermission
+    CLEANUP_ON_ERROR=1
     bugreport
     redact
     upload

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -110,6 +110,13 @@ $(get_installed_packages)
 EOF
 }
 
+cleanup() {
+    local exit_code=$?
+    if [ $exit_code -ne 0 ] && [ -n "${LOG_FILENAME:-}" ] && [ -f "$LOG_FILENAME" ]; then
+        rm -f "$LOG_FILENAME" 2>/dev/null || true
+    fi
+}
+
 emit_sensitive_values() {
     local replacement="$1"
     local value
@@ -123,12 +130,25 @@ collect_sensitive_values() {
     local real_user="${SUDO_USER:-}"
     local address_file
     local machine_id_file
+    local hn
+
+    if [ -z "$real_user" ] && [ -n "${PKEXEC_UID:-}" ]; then
+        real_user="$(id -nu "$PKEXEC_UID" 2>/dev/null || true)"
+    fi
+    if [ -z "$real_user" ]; then
+        real_user="$(logname 2>/dev/null || true)"
+    fi
 
     if [ -n "$real_user" ] && [ "$real_user" != "root" ]; then
         { getent passwd "$real_user" 2>/dev/null || true; } |
             cut -d: -f6 |
             emit_sensitive_values '<home-dir-redacted>'
         printf '%s\n' "$real_user" | emit_sensitive_values '<username-redacted>'
+    fi
+
+    hn="$(uname -n 2>/dev/null || hostname 2>/dev/null || cat /etc/hostname 2>/dev/null || true)"
+    if [ -n "$hn" ] && [ "$hn" != "localhost" ] && [ "$hn" != "(none)" ] && [ "${#hn}" -ge 2 ]; then
+        printf '%s\n' "$hn" | emit_sensitive_values '<hostname-redacted>'
     fi
 
     if command -v ip >/dev/null; then
@@ -154,16 +174,27 @@ collect_sensitive_values() {
     fi
 
     if command -v nmcli >/dev/null; then
-        { nmcli --terse --escape no --fields TYPE,NAME connection show 2>/dev/null || true; } |
-            sed -nE 's/^(802-11-wireless|wifi)://p' |
+        local uuid name ssid
+        while IFS=: read -r uuid name; do
+            [ -n "$name" ] && printf '%s\n' "$name"
+            if [ -n "$uuid" ]; then
+                ssid="$(nmcli -g 802-11-wireless.ssid connection show "$uuid" 2>/dev/null || true)"
+                [ -n "$ssid" ] && printf '%s\n' "$ssid"
+            fi
+        done < <({ nmcli --terse --escape no --fields TYPE,UUID,NAME connection show 2>/dev/null || true; } | sed -nE 's/^(802-11-wireless|wifi)://p') |
             emit_sensitive_values '<ssid-redacted>'
     fi
 
     if command -v udevadm >/dev/null; then
         { udevadm info --export-db 2>/dev/null || true; } |
             sed -n 's/^E: ID_SERIAL_SHORT=//p' |
+            grep -Ev '^[0-9a-fA-F]{2,4}:|^[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]$|^0+$|^[0-9]{1,2}$|^9876543210$|^1234567890$' |
             emit_sensitive_values '<usb-serial-redacted>'
     fi
+}
+
+sed_escape() {
+    printf '%s\n' "$1" | sed 's/[][\\.^$*+?(){}|#]/\\&/g'
 }
 
 redact() {
@@ -173,17 +204,20 @@ redact() {
     local replacement
     local value
 
-    # Escape a literal string for use in an extended sed pattern.
-    sed_escape() { printf '%s\n' "$1" | sed 's/[][\\.^$*+?(){}|]/\\&/g'; }
-
     while IFS=$'\t' read -r replacement value; do
         [ -n "$value" ] || continue
         if [ "$replacement" = '<username-redacted>' ]; then
-            sed_args+=(-e "s|\\b$(sed_escape "$value")\\b|${replacement}|g")
+            sed_args+=(-e "s#\\b$(sed_escape "$value")\\b#${replacement}#g")
+        elif [ "$replacement" = '<hostname-redacted>' ]; then
+            sed_args+=(-e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\2#g" \
+                       -e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\2#g")
         elif [ "$replacement" = '<ssid-redacted>' ]; then
-            sed_args+=(-e "/(SSID|ssid|access point|connected|connection|NetworkManager|wifi|Wi-Fi)/ s|$(sed_escape "$value")|${replacement}|g")
+            sed_args+=(-e "/(SSID|ssid|access point|connected|connection|NetworkManager|wifi|Wi-Fi)/ s#\\b$(sed_escape "$value")\\b#${replacement}#g")
+        elif [ "$replacement" = '<home-dir-redacted>' ]; then
+            sed_args+=(-e "s#$(sed_escape "$value")\\b#${replacement}#g")
         else
-            sed_args+=(-e "s|$(sed_escape "$value")|${replacement}|g")
+            [ "${#value}" -ge 3 ] || continue
+            sed_args+=(-e "s#\\b$(sed_escape "$value")\\b#${replacement}#g")
         fi
     done < <(collect_sensitive_values)
 
@@ -196,17 +230,19 @@ redact() {
     # Previous-boot values may no longer be present on the machine. Redact only
     # structured network, Wi-Fi and USB fields instead of guessing globally.
     sed_args+=(-e 's#\b(SRC|DST)=[^[:space:]]+#\1=<ip-address-redacted>#g')
-    sed_args+=(-e 's#((ip_address|address|gateway|nameserver)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
-    sed_args+=(-e 's#((ip_address|address|gateway|nameserver)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
+    sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
+    sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
+    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b(10\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[0-1])|192\.168|100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])|169\.254)\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]+)?\b#<ip-address-redacted>#g')
+    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b[0-9]{1,3}(\.[0-9]{1,3}){3}:[0-9]{2,5}\b#<ip-address-redacted>#g')
     sed_args+=(-e "s#((SSID|ssid)[=:][[:space:]]*)(\"[^\"]*\"|'[^']*'|[^[:space:]]+)#\\1<ssid-redacted>#g")
     sed_args+=(-e "s#((access point)[[:space:]]+)'[^']*'#\\1'<ssid-redacted>'#g")
     sed_args+=(-e 's#((SerialNumber|Serial Number|ID_SERIAL_SHORT)[=:][[:space:]]*)[^[:space:]]+#\1<usb-serial-redacted>#g')
     sed_args+=(-e 's#((machine-id|Machine ID)[=:][[:space:]]*)[[:xdigit:]]{32}#\1<machine-id-redacted>#g')
 
     # These formats are distinctive, or explicitly requested for all sections.
-    sed_args+=(-e 's#(^|[^[:xdigit:]:])([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^[:xdigit:]:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b#<mac-address-redacted>#g')
     sed_args+=(-e 's#\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b#<uuid-redacted>#g')
-    sed_args+=(-e 's#\b((PART)?UUID=)[0-9A-Fa-f-]+#\1<uuid-redacted>#g')
+    sed_args+=(-e 's#(^|[^a-zA-Z0-9])((PART|ID_FS_)?UUID=)[0-9A-Fa-f-]+#\1\2<uuid-redacted>#g')
     sed_args+=(-e 's#(/dev/disk/by-uuid/)[^[:space:]]+#\1<uuid-redacted>#g')
     sed_args+=(-e 's#"file://[^"]*"#"file://<path-redacted>"#g')
     sed_args+=(-e 's#[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}#<email-address-redacted>#g')
@@ -226,6 +262,7 @@ upload() {
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    trap cleanup EXIT
     check_root
     check_oldlog
     check_wpermission

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -184,6 +184,7 @@ collect_sensitive_values() {
                 [ -n "$ssid" ] && [ "${#ssid}" -ge 3 ] && printf '%s\n' "$ssid"
             fi
         done < <({ nmcli --terse --escape no --fields TYPE,UUID,NAME connection show 2>/dev/null || true; } | sed -nE 's/^(802-11-wireless|wifi)://p') |
+            grep -Ev '^(the|and|for|are|but|not|you|all|any|can|had|her|was|one|our|out|day|get|has|him|his|how|man|new|now|old|see|two|way|who|boy|did|its|let|put|say|she|too|use|off|yes|true|set|raw|end|low|top|bad|run|try|ask)$' -i |
             emit_sensitive_values '<ssid-redacted>'
     fi
 
@@ -215,7 +216,10 @@ redact() {
             sed_args+=(-e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g" \
                        -e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g")
         elif [ "$replacement" = '<ssid-redacted>' ]; then
-            sed_args+=(-e "/(SSID|ssid|access point|connected to|connection|NetworkManager|wifi|Wi-Fi)/ s#\\b$(sed_escape "$value")\\b#${replacement}#g")
+            if printf '%s\n' "$value" | grep -Eqi '^(the|and|for|are|but|not|you|all|any|can|had|her|was|one|our|out|day|get|has|him|his|how|man|new|now|old|see|two|way|who|boy|did|its|let|put|say|she|too|use|off|yes|true|set|raw|end|low|top|bad|run|try|ask)$'; then
+                continue
+            fi
+            sed_args+=(-e "/(SSID|ssid|access point|connected to|network|wifi|Wi-Fi|wlan)/ s#(^|[^a-zA-Z0-9])$(sed_escape "$value")([^a-zA-Z0-9]|$)#\\1${replacement}\\2#g")
         elif [ "$replacement" = '<home-dir-redacted>' ]; then
             sed_args+=(-e "s#$(sed_escape "$value")\\b#${replacement}#g")
         else
@@ -229,21 +233,27 @@ redact() {
     sed_args+=(-e 's#((hostname|Host Name)[=:][[:space:]]*)[^[:space:]]+#\1<hostname-redacted>#g')
     sed_args+=(-e 's#((Set hostname to|hostname set to)[[:space:]]+)[^[:space:].]+#\1<hostname-redacted>#gI')
 
-    # Previous-boot values may no longer be present on the machine. Redact only
-    # structured network, Wi-Fi and USB fields instead of guessing globally.
+    # Structured network, Wi-Fi and USB fields
     sed_args+=(-e 's#\b(SRC|DST)=[^[:space:]]+#\1=<ip-address-redacted>#g')
     sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
     sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
-    sed_args+=(-e '/(version|firmware|revision|bcdDevice)/! s#\b([0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]+)?\b#<ip-address-redacted>#g')
+
+    # IPv4 address redaction with diagnostic version protection and valid octet validation (0-255)
+    sed_args+=(-e 's#\b(version|firmware|revision|bcdDevice|release|build|rev|ver)[[:space:]:=]+([0-9]+(\.[0-9]+){3})\b#\1 __VER__\2__END__#gI')
+    sed_args+=(-e 's#\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(:[0-9]+)?\b#<ip-address-redacted>#g')
+    sed_args+=(-e 's#__VER__([0-9]+(\.[0-9]+){3})__END__#\1#g')
+
+    # Wi-Fi and USB fields
     sed_args+=(-e "s#((SSID|ssid)[=:][[:space:]]*)(\"[^\"]*\"|'[^']*'|[^[:space:]]+)#\\1<ssid-redacted>#g")
     sed_args+=(-e "s#((access point)[[:space:]]+)'[^']*'#\\1'<ssid-redacted>'#g")
     sed_args+=(-e 's#((SerialNumber|Serial Number|ID_SERIAL_SHORT)[=:][[:space:]]*)[^[:space:]]+#\1<usb-serial-redacted>#g')
     sed_args+=(-e 's#((machine-id|Machine ID)[=:][[:space:]]*)[[:xdigit:]]{32}#\1<machine-id-redacted>#g')
 
-    # Netfilter MAC= chains + standalone MAC addresses (ignoring longer colon-hex chains)
+    # MAC addresses: explicit Netfilter MAC= chains + labeled mac: fields + standalone MAC addresses (ignoring longer colon-hex chains)
     sed_args+=(-e 's#\bMAC=([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}#MAC=<mac-address-redacted>:<mac-address-redacted>#g')
-    sed_args+=(-e 's#(^|[^:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^:]|$)#\1<mac-address-redacted>\3#g')
-    sed_args+=(-e 's#(^|[^:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#\b((MAC|mac|HWaddr|hwaddr|ether|address|addr)[=:][[:space:]]*)([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b#\1<mac-address-redacted>#g')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
 
     # UUIDs, URLs, Email
     sed_args+=(-e 's#\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b#<uuid-redacted>#g')

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -124,7 +124,9 @@ emit_sensitive_values() {
     local value
 
     while IFS= read -r value; do
-        [ -n "$value" ] && [ "${#value}" -ge 3 ] && printf '%s\t%s\n' "$replacement" "$value"
+        if [ -n "$value" ] && [ "${#value}" -ge 3 ]; then
+            printf '%s\t%s\n' "$replacement" "$value"
+        fi
     done
 }
 
@@ -204,8 +206,14 @@ redact() {
     echo "Redacting personal information..."
 
     local sed_args=()
+    local inventory
     local replacement
     local value
+
+    if ! inventory="$(collect_sensitive_values)"; then
+        echo "ERROR: could not enumerate values to redact; refusing to continue." >&2
+        return 1
+    fi
 
     while IFS=$'\t' read -r replacement value; do
         [ -n "$value" ] || continue
@@ -228,7 +236,7 @@ redact() {
         else
             sed_args+=(-e "s#\\b$(sed_escape "$value")\\b#${replacement}#g")
         fi
-    done < <(collect_sensitive_values)
+    done <<<"$inventory"
 
     # Hostnames occur in fixed report fields. Avoid replacing generic hostnames in
     # useful strings such as linux-cachyos and cachyos-v4.

--- a/usr/bin/cachyos-bugreport.sh
+++ b/usr/bin/cachyos-bugreport.sh
@@ -216,10 +216,13 @@ redact() {
             sed_args+=(-e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g" \
                        -e "s#(^|[^a-zA-Z0-9_/-])$(sed_escape "$value")(-[0-9]+)?([^a-zA-Z0-9_/-]|$)#\\1${replacement}\\3#g")
         elif [ "$replacement" = '<ssid-redacted>' ]; then
-            if printf '%s\n' "$value" | grep -Eqi '^(the|and|for|are|but|not|you|all|any|can|had|her|was|one|our|out|day|get|has|him|his|how|man|new|now|old|see|two|way|who|boy|did|its|let|put|say|she|too|use|off|yes|true|set|raw|end|low|top|bad|run|try|ask)$'; then
-                continue
+            if printf '%s\n' "$value" | grep -Eqi '^(the|and|for|are|but|not|you|all|any|can|had|her|was|one|our|out|day|get|has|him|his|how|man|new|now|old|see|two|way|who|boy|did|its|let|put|say|she|too|use|off|yes|true|set|raw|end|low|top|bad|run|try|ask|this)$'; then
+                sed_args+=(-e "s#((SSID|ssid|access point|connected to|connecting to|associated with|association with|network|connection|saw)[=:[:space:]]+['\"]?)$(sed_escape "$value")(['\"]?([^a-zA-Z0-9]|$))#\\1${replacement}\\3#gI" \
+                           -e "s#((SSID|ssid|access point|connected to|connecting to|associated with|association with|network|connection|saw)[=:[:space:]]+['\"]?)$(sed_escape "$value")(['\"]?([^a-zA-Z0-9]|$))#\\1${replacement}\\3#gI")
+            else
+                sed_args+=(-e "/(SSID|ssid|access point|connected to|associated with|association with|connection|NetworkManager|wlan[0-9]|wifi|Wi-Fi)/I s#(^|[^a-zA-Z0-9])$(sed_escape "$value")([^a-zA-Z0-9]|$)#\\1${replacement}\\2#g" \
+                           -e "/(SSID|ssid|access point|connected to|associated with|association with|connection|NetworkManager|wlan[0-9]|wifi|Wi-Fi)/I s#(^|[^a-zA-Z0-9])$(sed_escape "$value")([^a-zA-Z0-9]|$)#\\1${replacement}\\2#g")
             fi
-            sed_args+=(-e "/(SSID|ssid|access point|connected to|network|wifi|Wi-Fi|wlan)/ s#(^|[^a-zA-Z0-9])$(sed_escape "$value")([^a-zA-Z0-9]|$)#\\1${replacement}\\2#g")
         elif [ "$replacement" = '<home-dir-redacted>' ]; then
             sed_args+=(-e "s#$(sed_escape "$value")\\b#${replacement}#g")
         else
@@ -233,15 +236,15 @@ redact() {
     sed_args+=(-e 's#((hostname|Host Name)[=:][[:space:]]*)[^[:space:]]+#\1<hostname-redacted>#g')
     sed_args+=(-e 's#((Set hostname to|hostname set to)[[:space:]]+)[^[:space:].]+#\1<hostname-redacted>#gI')
 
-    # Structured network, Wi-Fi and USB fields
+    # Structured network fields with shared valid IPv4 octet semantics
     sed_args+=(-e 's#\b(SRC|DST)=[^[:space:]]+#\1=<ip-address-redacted>#g')
-    sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9]{1,3}(\.[0-9]{1,3}){3}#\1<ip-address-redacted>#g')
+    sed_args+=(-e 's#\b(([a-zA-Z0-9_]*(ip_address|address|gateway|nameserver|endpoint|server|host|mirror|contacted|firmware))[=:][>[:space:]]*)(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(:[0-9]+)?#\1<ip-address-redacted>#gI')
+    sed_args+=(-e 's#\b(contacted|endpoint|server|mirror)[[:space:]]+(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(:[0-9]+)?#\1 <ip-address-redacted>#gI')
     sed_args+=(-e 's#((ip_address|address|gateway|nameserver|endpoint)[=:][>[:space:]]*)[0-9A-Fa-f]*:[0-9A-Fa-f:.%]+#\1<ip-address-redacted>#g')
+    sed_args+=(-e 's#\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}:[0-9]{2,5}\b#<ip-address-redacted>#g')
 
-    # IPv4 address redaction with diagnostic version protection and valid octet validation (0-255)
-    sed_args+=(-e 's#\b(version|firmware|revision|bcdDevice|release|build|rev|ver)[[:space:]:=]+([0-9]+(\.[0-9]+){3})\b#\1 __VER__\2__END__#gI')
-    sed_args+=(-e 's#\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(:[0-9]+)?\b#<ip-address-redacted>#g')
-    sed_args+=(-e 's#__VER__([0-9]+(\.[0-9]+){3})__END__#\1#g')
+    # Standalone valid IPv4 address redaction preserving diagnostic dotted releases/versions
+    sed_args+=(-e '/\b(version|release|kernel|bcdDevice|revision)([[:space:]]+(is|version|release|tag|of))?[[:space:]:=]+[0-9]+(\.[0-9]+){3}\b/I! s#\b(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}\b#<ip-address-redacted>#g')
 
     # Wi-Fi and USB fields
     sed_args+=(-e "s#((SSID|ssid)[=:][[:space:]]*)(\"[^\"]*\"|'[^']*'|[^[:space:]]+)#\\1<ssid-redacted>#g")
@@ -249,11 +252,12 @@ redact() {
     sed_args+=(-e 's#((SerialNumber|Serial Number|ID_SERIAL_SHORT)[=:][[:space:]]*)[^[:space:]]+#\1<usb-serial-redacted>#g')
     sed_args+=(-e 's#((machine-id|Machine ID)[=:][[:space:]]*)[[:xdigit:]]{32}#\1<machine-id-redacted>#g')
 
-    # MAC addresses: explicit Netfilter MAC= chains + labeled mac: fields + standalone MAC addresses (ignoring longer colon-hex chains)
+    # MAC addresses: explicit Netfilter MAC= chains + labeled fields (with case/prefix support) + standalone MACs (preserving longer colon-hex/IPv6)
     sed_args+=(-e 's#\bMAC=([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}#MAC=<mac-address-redacted>:<mac-address-redacted>#g')
-    sed_args+=(-e 's#\b((MAC|mac|HWaddr|hwaddr|ether|address|addr)[=:][[:space:]]*)([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b#\1<mac-address-redacted>#g')
-    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
-    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])([a-zA-Z0-9_]*(MAC|mac|HWaddr|hwaddr|ether|address|addr)[=:][[:space:]]*)([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^0-9A-Fa-f:]|$)#\1\2<mac-address-redacted>\5#gI')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])([a-zA-Z0-9_]*(MAC|mac|HWaddr|hwaddr|ether|address|addr)[=:][[:space:]]*)([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^0-9A-Fa-f:]|$)#\1\2<mac-address-redacted>\5#gI')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
+    sed_args+=(-e 's#(^|[^0-9A-Fa-f:])([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}([^0-9A-Fa-f:]|$)#\1<mac-address-redacted>\3#g')
 
     # UUIDs, URLs, Email
     sed_args+=(-e 's#\b[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}\b#<uuid-redacted>#g')


### PR DESCRIPTION
## Summary

- enumerate current sensitive machine values and redact those exact literals instead of globally guessing at address-like strings
- suppress or redact hostnames only in structured report positions, preserving useful `linux-cachyos`, `cachyos-v4`, and kernel-version diagnostics
- retain narrow fallbacks for historical journal fields and add deterministic synthetic regression coverage

This addresses #250.

## Why this approach

Compared with #252, this avoids the broad IPv4 substitution that can turn a firmware version such as `6.18.44.1` into a false positive. It also handles privacy cases that implementation misses: compressed IPv6, 32-character machine IDs, USB serial numbers, nonstandard filesystem UUIDs, and empty Wi-Fi inventories.

Current values are collected from reliable system sources for IPv4/IPv6 addresses, MAC addresses, machine IDs, filesystem UUIDs, saved SSIDs, USB serials, and the invoking user's name/home. Historical previous-boot values that may no longer exist in current state are covered only in structured UFW, DHCP, SSID, UUID, machine-id, and USB fields.

Journal hostnames are suppressed at collection time, while the `uname` hostname is redacted positionally. Quoted `file://` paths are redacted one URL at a time so multiple URLs on a line do not consume useful intervening diagnostics.

## Tests

- `tests/test-bugreport-redaction.sh`
- `bash -n usr/bin/cachyos-bugreport.sh`
- `bash -n tests/test-bugreport-redaction.sh`
- `git diff HEAD^ --check`

The synthetic test covers current and historical IPv4/IPv6, MAC addresses, machine IDs, filesystem UUIDs, SSIDs, USB serials, username/home paths, multiple quoted file URLs, generic hostnames, preserved CachyOS package/kernel strings, the firmware-version false positive, and empty inventory behavior.
